### PR TITLE
Tweak: ensure discovered tags match the expected pattern

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -43,7 +43,7 @@ jobs:
           else
              echo "RELEASE_MODE=false" >> $GITHUB_ENV
              echo "DRAFT_RELEASE=false" >> $GITHUB_ENV
-             tag_sha=$(git describe --tags --always)
+             tag_sha=$(git describe --tags --always --match='v[0-9]*')
              echo "VERSION=$tag_sha" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -43,7 +43,7 @@ jobs:
           else
              echo "RELEASE_MODE=false" >> $GITHUB_ENV
              echo "DRAFT_RELEASE=false" >> $GITHUB_ENV
-             tag_sha=$(git describe --tags --always)
+             tag_sha=$(git describe --tags --always --match='v[0-9]*')
              echo "VERSION=$tag_sha" >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
In the `prepare_env` workflow, we do not restrict the git tags used to set `tag_sha`, which is a variable that eventually determines the file name of the packaged Jar. This change adds the `--match='v[0-9]*'` parameter to our `git describe --tags` call, to ensure we do not accidentally use tags that do not refer to a public release.