### PR TITLE
[CKC-58]Primary Keys null validation

### DIFF
--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTask.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTask.scala
@@ -138,9 +138,9 @@ class EmsSinkTask extends SinkTask with StrictLogging {
             value <- obfuscation.fold(IO.pure(v)) { o =>
               IO.fromEither(v.obfuscate(o).leftMap(FailedObfuscationException))
             }
-            _       <- IO.fromEither(pksValidator.validate(value))
             tp       = TopicPartition(new Topic(record.topic()), new Partition(record.kafkaPartition()))
             metadata = RecordMetadata(tp, new Offset(record.kafkaOffset()))
+            _       <- IO.fromEither(pksValidator.validate(value, metadata))
             _       <- writerManager.write(Record(value, metadata))
           } yield ()
         }


### PR DESCRIPTION
#### Description

Currently, the connector allows the user to pick up the primary keys list. However, a primary key value cannnot and should not be null.

This PR introduces an extra validation in PrimaryKeysValidator class to ensure a PK field value is not null. In case it is, an error will be returned.

#### Tests

Unit tests coverage was added to confirm the null-pk checks.