### PR TITLE
CKC-62 | Upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ git push origin vx.y.z
 
 The release will be automatically generated after the action has finished successfully.
 
+## Locally run a vulnerability scan
+
+- Make sure you have [dependency-check](https://owasp.org/www-project-dependency-check/) installed
+- Generate the jar for the connector:
+```
+sbt> project kafka-ems-connector; clean; generateManifest; project connector; set assembly / test := {}; assembly 
+``` 
+- Use `dependency-check` to scan the jar:
+```
+dependency-check -s ./connector/target/scala-2.13/kafka-ems-sink-assembly-1.1-SNAPSHOT.jar
+```
 
 ## Bugs and Feedback
 For bugs, questions and discussions please use the GitHub Issues.

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ import Settings._
 import sbt._
 
 ThisBuild / scalafixDependencies ++= Dependencies.scalafixDeps
-// This line ensures that sources are downloaded for dependencies, when using Bloop
-bloopExportJarClassifiers in Global := Some(Set("sources"))
 
 val generateManifest = taskKey[Seq[File]]("generateManifest")
 

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/config/EmsSinkConfigTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/config/EmsSinkConfigTest.scala
@@ -259,7 +259,7 @@ class EmsSinkConfigTest extends AnyFunSuite with Matchers {
         false,
       )
 
-      val inputMap: Map[String, _] = Map(
+      val inputMap = Map[String, Any](
         ENDPOINT_KEY                -> sinkConfig.url.toString,
         TARGET_TABLE_KEY            -> sinkConfig.target,
         AUTHORIZATION_KEY           -> sinkConfig.authorization.header,

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTaskObfuscationTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTaskObfuscationTest.scala
@@ -17,12 +17,18 @@
 package com.celonis.kafka.connect.ems.sink
 
 import cats.data.NonEmptyList
-import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants.{CLOSE_EVERY_CONNECTION_DEFAULT_VALUE => CLOSE_CONN_DEFAULT, CONNECTION_POOL_KEEPALIVE_MILLIS_DEFAULT_VALUE => KEEPALIVE_DEFAULT, CONNECTION_POOL_MAX_IDLE_CONNECTIONS_DEFAULT_VALUE => MAX_IDLE_DEFAULT, _}
+import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants.{
+  CLOSE_EVERY_CONNECTION_DEFAULT_VALUE => CLOSE_CONN_DEFAULT,
+  CONNECTION_POOL_KEEPALIVE_MILLIS_DEFAULT_VALUE => KEEPALIVE_DEFAULT,
+  CONNECTION_POOL_MAX_IDLE_CONNECTIONS_DEFAULT_VALUE => MAX_IDLE_DEFAULT,
+  _,
+}
 import com.celonis.kafka.connect.ems.config._
 import com.celonis.kafka.connect.ems.errors.ErrorPolicy.Retry
 import com.celonis.kafka.connect.ems.model.DataObfuscation.FixObfuscation
 import com.celonis.kafka.connect.ems.model.DefaultCommitPolicy
-import com.celonis.kafka.connect.ems.storage.{ParquetFileCleanupRename, WorkingDirectory}
+import com.celonis.kafka.connect.ems.storage.ParquetFileCleanupRename
+import com.celonis.kafka.connect.ems.storage.WorkingDirectory
 import com.celonis.kafka.connect.transform.fields.EmbeddedKafkaMetadataFieldInserter
 import com.sksamuel.avro4s.RecordFormat
 import io.confluent.connect.avro.AvroData

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/ProxyEndpoint.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/ProxyEndpoint.scala
@@ -37,6 +37,7 @@ import org.typelevel.ci.CIString
 
 import java.util.Base64
 import scala.util.Try
+import scala.util.matching.Regex
 
 class ProxyEndpoint[F[_]: Concurrent](
   auth: Option[BasicAuthentication],
@@ -67,7 +68,7 @@ class ProxyEndpoint[F[_]: Concurrent](
   }
 
   def splitAuth(authHeaderValue: String): Option[String] = {
-    val reg = "^Basic ([A-Za-z0-9]*)$".r("base64gp")
+    val reg = new Regex("^Basic ([A-Za-z0-9]*)$", "base64gp")
     for {
       matches <- reg.findFirstMatchIn(authHeaderValue)
     } yield matches.group("base64gp")

--- a/connector/src/test/scala/com/celonis/kafka/connect/transform/InferSchemaAndNormaliseValueTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/transform/InferSchemaAndNormaliseValueTest.scala
@@ -78,7 +78,7 @@ class InferSchemaAndNormaliseValueTest extends org.scalatest.funsuite.AnyFunSuit
     List(
       Map.empty[Boolean, Boolean].asJava -> SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BYTES_SCHEMA).build(),
       List.empty[Int].asJava             -> SchemaBuilder.array(Schema.BYTES_SCHEMA).build(),
-      List(1, "blah", true).asJava       -> SchemaBuilder.array(Schema.BYTES_SCHEMA).build(),
+      List[Any](1, "blah", true).asJava  -> SchemaBuilder.array(Schema.BYTES_SCHEMA).build(),
     ).foreach {
       case (value, expectedSchema) =>
         assertResult(Some(ValueAndSchema(value, expectedSchema)))(InferSchemaAndNormaliseValue(value))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -175,6 +175,7 @@ object Dependencies {
     .excludeAll(ExclusionRule(organization = "org.apache.zookeeper"))
     .exclude("org.apache.hadoop", "hadoop-annotations")
     .exclude("org.apache.hadoop", "hadoop-auth")
+    .exclude("org.apache.hadoop.thirdparty", "hadoop-shaded-protobuf_3_7")
 
   lazy val hadoopMapReduce = ("org.apache.hadoop" % "hadoop-mapreduce-client-core" % Versions.hadoopVersion)
     .excludeAll(ExclusionRule(organization = "javax.servlet"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,9 +67,9 @@ object Dependencies {
 
     val wiremockJre8Version = "2.25.1"
     val parquetVersion      = "1.12.2"
-    val hadoopVersion       = "3.2.4"
+    val hadoopVersion       = "3.3.4"
 
-    val nettyVersion = "4.1.77.Final"
+    val nettyVersion = "4.1.89.Final"
 
     val nimbusJoseJwtVersion = "9.22"
 
@@ -79,8 +79,8 @@ object Dependencies {
     val mockServerClientVersion = "5.5.4"
     val httpClientVersion       = "4.5.13"
     val json4sVersion           = "4.0.5"
-    val jacksonVersion          = "2.12.6"
-    val jacksonDatabindVersion  = "2.12.6.1"
+    val jacksonVersion          = "2.14.2"
+    val jacksonDatabindVersion  = "2.14.2"
     val slf4jTestingVersion     = "2.0.0-alpha1"
   }
 
@@ -103,8 +103,7 @@ object Dependencies {
 
   val circeGeneric = "io.circe" %% "circe-generic" % Versions.circeVersion
   val circeParser  = "io.circe" %% "circe-parser"  % Versions.circeVersion
-  val circeRefined = "io.circe" %% "circe-refined" % Versions.circeVersion
-  val circe        = Seq(circeGeneric, circeParser, circeRefined)
+  val circe        = Seq(circeGeneric, circeParser)
 
   // logging
   val logback          = "ch.qos.logback"              % "logback-classic" % Versions.logbackVersion
@@ -170,6 +169,7 @@ object Dependencies {
     .excludeAll(ExclusionRule(organization = "com.fasterxml.jackson.core"))
     .excludeAll(ExclusionRule(organization = "com.fasterxml.jackson.databind"))
     .excludeAll(ExclusionRule(organization = "com.google.protobuf"))
+    .excludeAll(ExclusionRule(organization = "commons-net"))
     .exclude("org.apache.hadoop", "hadoop-annotations")
     .exclude("org.apache.hadoop", "hadoop-auth")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   // scala versions
   val scalaOrganization      = "org.scala-lang"
   val scala212Version        = "2.12.13"
-  val scala213Version        = "2.13.5"
+  val scala213Version        = "2.13.10"
   val supportedScalaVersions = List(scala213Version)
 
   val commonResolvers = Seq(
@@ -34,7 +34,7 @@ object Dependencies {
     val scalaCheckVersion              = "1.14.3"
     val randomDataGeneratorVersion     = "2.8"
 
-    val enumeratumVersion = "1.7.0"
+    val enumeratumVersion = "1.7.2"
 
     val kafkaVersion = "3.1.0"
 
@@ -68,6 +68,7 @@ object Dependencies {
     val wiremockJre8Version = "2.25.1"
     val parquetVersion      = "1.12.2"
     val hadoopVersion       = "3.3.4"
+    val woodstockVersion    = "5.4.0"
 
     val nettyVersion = "4.1.89.Final"
 
@@ -170,6 +171,8 @@ object Dependencies {
     .excludeAll(ExclusionRule(organization = "com.fasterxml.jackson.databind"))
     .excludeAll(ExclusionRule(organization = "com.google.protobuf"))
     .excludeAll(ExclusionRule(organization = "commons-net"))
+    .excludeAll(ExclusionRule(organization = "org.apache.kerby"))
+    .excludeAll(ExclusionRule(organization = "org.apache.zookeeper"))
     .exclude("org.apache.hadoop", "hadoop-annotations")
     .exclude("org.apache.hadoop", "hadoop-auth")
 
@@ -184,9 +187,14 @@ object Dependencies {
     .excludeAll(ExclusionRule(organization = "com.fasterxml.jackson.core"))
     .excludeAll(ExclusionRule(organization = "com.fasterxml.jackson.databind"))
     .excludeAll(ExclusionRule(organization = "com.google.protobuf"))
+    .excludeAll(ExclusionRule(organization = "org.apache.zookeeper"))
     .exclude("org.apache.hadoop", "hadoop-yarn-common")
+    .exclude("org.apache.hadoop", "hadoop-hdfs-client")
     .exclude("org.apache.hadoop", "hadoop-yarn-client")
 
+  //this is a vulnerability fix. hadoop-common brings 5.3.0 and there is no new version of hadoop-common addressing the issue
+  // hence the build brings 5.4.0
+  lazy val woodstock = "com.fasterxml.woodstox" % "woodstox-core" % Versions.woodstockVersion
   // testcontainers module dependencies
   val testcontainersCore       = "org.testcontainers"        % "testcontainers"         % Versions.testcontainersVersion
   val testcontainersKafka      = "org.testcontainers"        % "kafka"                  % Versions.testcontainersVersion
@@ -293,6 +301,7 @@ trait Dependencies {
     parquetHadoop,
     hadoopCommon,
     hadoopMapReduce,
+    woodstock,
   ) ++ enumeratum ++ circe ++ http4s ++ nettyDeps).map(_.exclude("org.slf4j", "slf4j-log4j12"))
     .map(_.exclude("org.apache.logging.log4j", "log4j-slf4j-impl"))
     .map(_.exclude("com.sun.jersey", "*"))

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -53,7 +53,8 @@ object Settings extends Dependencies {
 
     val commonOptions = Seq(
       // standard settings
-      "-target:jvm-1.8",
+      "-release",
+      "8",
       "-encoding",
       "UTF-8",
       "-unchecked",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,8 +7,7 @@ addSbtPlugin("io.spray"                          % "sbt-revolver"       % "0.9.1
 addSbtPlugin("org.scoverage"                     % "sbt-scoverage"      % "1.9.3")
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"         % "5.6.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"   % "3.0.2")
-addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"       % "0.9.26")
-addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"          % "1.4.8")
+addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"       % "0.10.4")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"      % "0.10.0")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-license-report" % "1.2.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,6 @@ addSbtPlugin("ch.epfl.scala"                     % "sbt-bloop"          % "1.4.8
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"      % "0.10.0")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-license-report" % "1.2.0")
 
-addSbtPlugin("net.vonbuchholtz"    % "sbt-dependency-check" % "3.1.1")
+addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "3.1.1")
 addDependencyTreePlugin
-libraryDependencies += "org.slf4j" % "slf4j-nop"            % "1.7.25"
+libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,4 +13,5 @@ addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"      % "0.10.
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-license-report" % "1.2.0")
 
 addSbtPlugin("net.vonbuchholtz"    % "sbt-dependency-check" % "3.1.1")
+addDependencyTreePlugin
 libraryDependencies += "org.slf4j" % "slf4j-nop"            % "1.7.25"


### PR DESCRIPTION
Upgrade the following libraries to the latest and greatest:

- bump scala version to 2.13.10.
- `hadoop-common` (used for Parquet file encoding), and tweak its exclusion rule.
- `jackson-core` and `jackson-databind`.
- explicitly set the version of woodstox, ensuring that older/vulnerable versions are evicted by the build tool.
- remove `circe-refined` as it's not used and brings in additional transitive dependencies.
- remove the `bloop` build time dependency.


