### PR TITLE
bugfix: decouple kafka metadata fields from __celonisOrder

### DIFF
--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/EmbeddedKafkaMetadataFieldInserter.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/EmbeddedKafkaMetadataFieldInserter.scala
@@ -33,8 +33,8 @@ class EmbeddedKafkaMetadataFieldInserter(fieldsToInsert: FieldsToInsert) extends
   override def insertFields(value: Any, meta: EmbeddedKafkaMetadata): Any =
     value match {
       case value: Struct =>
-        val s       = value.schema()
-        val fields  = s.fields().asScala.toList
+        val s        = value.schema()
+        val fields   = s.fields().asScala.toList
         val startIdx = fields.map(_.index()).maxOption.map(_ + 1).getOrElse(0)
 
         val additionalFields = fieldsToInsert match {

--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/EmbeddedKafkaMetadataFieldInserter.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/EmbeddedKafkaMetadataFieldInserter.scala
@@ -4,31 +4,49 @@ import org.apache.kafka.connect.data.ConnectSchema
 import org.apache.kafka.connect.data.Field
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.Struct
+
 import scala.jdk.CollectionConverters._
 
-object EmbeddedKafkaMetadataFieldInserter extends FieldInserter {
+object EmbeddedKafkaMetadataFieldInserter {
   private val PartitionFieldName       = "kafkaPartition"
   private val OffsetFieldName          = "kafkaOffset"
   private val Timestamp                = "kafkaTimestamp"
   private val PartitionOffsetFieldName = "kafkaPartitionOffset"
 
-  //legacy field, kept for backward compatibility with previus connector versions
+  //legacy field, kept for backward compatibility with previous connector versions
   private[connect] val CelonisOrderFieldName = "__celonis_order"
+
+  private val PartitionOffsetTimestampFields = Seq(
+    PartitionFieldName       -> Schema.INT32_SCHEMA,
+    OffsetFieldName          -> Schema.INT64_SCHEMA,
+    Timestamp                -> Schema.INT64_SCHEMA,
+    PartitionOffsetFieldName -> Schema.STRING_SCHEMA,
+  )
+
+  private val CelonisOrderFields = Seq(
+    CelonisOrderFieldName -> Schema.INT64_SCHEMA,
+  )
+}
+class EmbeddedKafkaMetadataFieldInserter(fieldsToInsert: FieldsToInsert) extends FieldInserter {
+  import EmbeddedKafkaMetadataFieldInserter._
 
   override def insertFields(value: Any, meta: EmbeddedKafkaMetadata): Any =
     value match {
       case value: Struct =>
         val s       = value.schema()
         val fields  = s.fields().asScala.toList
-        val nextIdx = fields.map(_.index()).maxOption.map(_ + 1).getOrElse(0)
+        val startIdx = fields.map(_.index()).maxOption.map(_ + 1).getOrElse(0)
 
-        val newFields = fields ++ List(
-          new Field(PartitionFieldName, nextIdx, Schema.INT32_SCHEMA),
-          new Field(OffsetFieldName, nextIdx + 1, Schema.INT64_SCHEMA),
-          new Field(Timestamp, nextIdx + 2, Schema.INT64_SCHEMA),
-          new Field(PartitionOffsetFieldName, nextIdx + 3, Schema.STRING_SCHEMA),
-          new Field(CelonisOrderFieldName, nextIdx + 4, Schema.INT64_SCHEMA),
-        )
+        val additionalFields = fieldsToInsert match {
+          case FieldsToInsert.PartitionOffsetTimestamp =>
+            PartitionOffsetTimestampFields
+          case FieldsToInsert.CelonisOrder =>
+            CelonisOrderFields
+          case FieldsToInsert.All =>
+            PartitionOffsetTimestampFields ++ CelonisOrderFields
+        }
+
+        val newFields = fields ++ fieldsWithIndex(startIdx)(additionalFields: _*)
 
         val newSchema = new ConnectSchema(s.`type`(),
                                           s.isOptional,
@@ -55,5 +73,10 @@ object EmbeddedKafkaMetadataFieldInserter extends FieldInserter {
         newValue
 
       case _ => value
+    }
+
+  private def fieldsWithIndex(startIdx: Int)(fieldSchemas: (String, Schema)*): Seq[Field] =
+    LazyList.from(startIdx).zip(fieldSchemas).map {
+      case (idx, (fieldName, schema)) => new Field(fieldName, idx, schema)
     }
 }

--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/FieldInserter.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/FieldInserter.scala
@@ -9,8 +9,10 @@ object FieldInserter {
   }
 
   def embeddedKafkaMetadata(doInsert: Boolean, configuredOrderField: Option[String]): FieldInserter =
-    if (doInsert || configuredOrderField.contains(EmbeddedKafkaMetadataFieldInserter.CelonisOrderFieldName))
-      EmbeddedKafkaMetadataFieldInserter
-    else
-      noop
+    (doInsert, configuredOrderField.contains(EmbeddedKafkaMetadataFieldInserter.CelonisOrderFieldName)) match {
+      case (true, true)   => new EmbeddedKafkaMetadataFieldInserter(FieldsToInsert.All)
+      case (true, false)  => new EmbeddedKafkaMetadataFieldInserter(FieldsToInsert.PartitionOffsetTimestamp)
+      case (false, true)  => new EmbeddedKafkaMetadataFieldInserter(FieldsToInsert.CelonisOrder)
+      case (false, false) => noop
+    }
 }

--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/FieldsToInsert.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/FieldsToInsert.scala
@@ -1,0 +1,8 @@
+package com.celonis.kafka.connect.transform.fields
+
+sealed trait FieldsToInsert
+object FieldsToInsert {
+  case object PartitionOffsetTimestamp extends FieldsToInsert
+  case object CelonisOrder extends FieldsToInsert
+  case object All extends FieldsToInsert
+}

--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/FieldsToInsert.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/fields/FieldsToInsert.scala
@@ -3,6 +3,6 @@ package com.celonis.kafka.connect.transform.fields
 sealed trait FieldsToInsert
 object FieldsToInsert {
   case object PartitionOffsetTimestamp extends FieldsToInsert
-  case object CelonisOrder extends FieldsToInsert
-  case object All extends FieldsToInsert
+  case object CelonisOrder             extends FieldsToInsert
+  case object All                      extends FieldsToInsert
 }

--- a/connector/src/test/scala/com/celonis/kafka/connect/transform/RecordTransformerTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/transform/RecordTransformerTest.scala
@@ -47,10 +47,6 @@ class RecordTransformerTest extends AnyFunSuite with Matchers {
     }
   }
 
-  test("With embed kafka metadata disabled, doesn't include partition/offset fields") {
-
-  }
-
   private def chunkTransform(record: SinkRecord, maxChunks: Int, chunkSize: Int): GenericRecord = {
     val flattenerConfig = Some(FlattenerConfig(discardCollections = false, Some(JsonBlobChunks(maxChunks, chunkSize))))
     val transformer     = RecordTransformer.fromConfig("mySink", flattenerConfig, Nil, None, FieldInserter.noop)

--- a/connector/src/test/scala/com/celonis/kafka/connect/transform/RecordTransformerTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/transform/RecordTransformerTest.scala
@@ -47,6 +47,10 @@ class RecordTransformerTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("With embed kafka metadata disabled, doesn't include partition/offset fields") {
+
+  }
+
   private def chunkTransform(record: SinkRecord, maxChunks: Int, chunkSize: Int): GenericRecord = {
     val flattenerConfig = Some(FlattenerConfig(discardCollections = false, Some(JsonBlobChunks(maxChunks, chunkSize))))
     val transformer     = RecordTransformer.fromConfig("mySink", flattenerConfig, Nil, None, FieldInserter.noop)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // Activate the following only when needed to use specific tasks like `whatDependsOn` etc...
 //addDependencyTreePlugin
 
-addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"       % "2.3.1")
+addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"       % "2.4.6")
 addSbtPlugin("com.typesafe.sbt"                  % "sbt-git"            % "1.0.0")
 addSbtPlugin("io.spray"                          % "sbt-revolver"       % "0.9.1")
 addSbtPlugin("org.scoverage"                     % "sbt-scoverage"      % "1.9.3")


### PR DESCRIPTION
Currently setting `connect.ems.embed.kafka.metadata=false` may have no effect. This is because:
-  we were instantiating an actual `EmbeddedKafkaMetadataFieldInserter` when `configuredOrderField` is set to `__celonis_order`.
-  `connect.ems.order.field.name` defaults to `__celonis_order` whenever a primary key is set (via `connect.ems.data.primary.key`).

This PR  makes EmbeddedKafkaMetadataFieldInserter more flexible as it allows to set the exact combination of fields to be embedded in the transformed payload. This means that one can have `__celonis_order` without setting `partition`, `offsets`, etc.