### PR TITLE
XML Converter

### DIFF
--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/converter/XmlConverter.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/converter/XmlConverter.scala
@@ -1,0 +1,23 @@
+package com.celonis.kafka.connect.ems.converter
+
+import com.fasterxml.jackson.core.`type`.TypeReference
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaAndValue
+import org.apache.kafka.connect.storage.Converter
+
+import java.util
+
+final class XmlConverter extends Converter {
+  override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
+
+  override def fromConnectData(topic: String, schema: Schema, value: Any): Array[Byte] =
+    throw new NotImplementedError("XML Serialization has not been implemented")
+
+  override def toConnectData(topic: String, value: Array[Byte]): SchemaAndValue = {
+    val mapper        = new XmlMapper()
+    val typeReference = new TypeReference[Any]() {}
+    val node          = mapper.readValue(value, typeReference)
+    new SchemaAndValue(null, node)
+  }
+}

--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/converter/XmlConverter.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/converter/XmlConverter.scala
@@ -9,14 +9,15 @@ import org.apache.kafka.connect.storage.Converter
 import java.util
 
 final class XmlConverter extends Converter {
+  private val mapper = new XmlMapper()
+  private val typeReference = new TypeReference[Any]() {}
+
   override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
 
   override def fromConnectData(topic: String, schema: Schema, value: Any): Array[Byte] =
     throw new NotImplementedError("XML Serialization has not been implemented")
 
   override def toConnectData(topic: String, value: Array[Byte]): SchemaAndValue = {
-    val mapper        = new XmlMapper()
-    val typeReference = new TypeReference[Any]() {}
     val node          = mapper.readValue(value, typeReference)
     new SchemaAndValue(null, node)
   }

--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/converter/XmlConverter.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/converter/XmlConverter.scala
@@ -9,7 +9,7 @@ import org.apache.kafka.connect.storage.Converter
 import java.util
 
 final class XmlConverter extends Converter {
-  private val mapper = new XmlMapper()
+  private val mapper        = new XmlMapper()
   private val typeReference = new TypeReference[Any]() {}
 
   override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = ()
@@ -18,7 +18,7 @@ final class XmlConverter extends Converter {
     throw new NotImplementedError("XML Serialization has not been implemented")
 
   override def toConnectData(topic: String, value: Array[Byte]): SchemaAndValue = {
-    val node          = mapper.readValue(value, typeReference)
+    val node = mapper.readValue(value, typeReference)
     new SchemaAndValue(null, node)
   }
 }

--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/converter/XmlConverter.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/converter/XmlConverter.scala
@@ -17,8 +17,12 @@ final class XmlConverter extends Converter {
   override def fromConnectData(topic: String, schema: Schema, value: Any): Array[Byte] =
     throw new NotImplementedError("XML Serialization has not been implemented")
 
-  override def toConnectData(topic: String, value: Array[Byte]): SchemaAndValue = {
-    val node = mapper.readValue(value, typeReference)
-    new SchemaAndValue(null, node)
-  }
+  override def toConnectData(topic: String, value: Array[Byte]): SchemaAndValue =
+    value match {
+      case null => SchemaAndValue.NULL
+      case nonNullValue =>
+        val node = mapper.readValue(nonNullValue, typeReference)
+        new SchemaAndValue(null, node)
+    }
+
 }

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/converter/XmlConverterTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/converter/XmlConverterTest.scala
@@ -1,9 +1,11 @@
 package com.celonis.kafka.connect.ems.converter
 
 import org.apache.kafka.connect.data.SchemaAndValue
+import org.apache.kafka.connect.errors.DataException
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
+import java.nio.charset.StandardCharsets
 import scala.collection.immutable.ListMap
 import scala.jdk.CollectionConverters._
 
@@ -52,6 +54,13 @@ class XmlConverterTest extends AnyFunSuite with Matchers {
 
     value shouldBe expected
 
+  }
+
+  test("it should throw a Connect DataException for deserialisation errors") {
+    an[DataException] should be thrownBy (converter.toConnectData(
+      "topic",
+      "<root>invalid xml</bleah>".getBytes(StandardCharsets.UTF_8),
+    ))
   }
 
   // Recursively transform collections, and preserve Maps traversal order

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/converter/XmlConverterTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/converter/XmlConverterTest.scala
@@ -1,0 +1,65 @@
+package com.celonis.kafka.connect.ems.converter
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.immutable.ListMap
+import scala.jdk.CollectionConverters._
+
+class XmlConverterTest extends AnyFunSuite with Matchers {
+  test("it should convert xml") {
+    val xml =
+      """
+        |<root>
+        | <order id="1">
+        |   <item>Item 1</item>
+        |   <item><inner>Item 2</inner></item>
+        |   <different>a</different>
+        |   <item>Item 3</item>
+        | </order>
+        | <order id="2">
+        |   <item>Item 1</item>
+        |   <item>Item 2</item>
+        |   <item>Item 3</item>
+        | </order>
+        | <other>something else</other>
+        |</root>
+        |""".stripMargin
+
+    val converter   = new XmlConverter
+    val connectData = converter.toConnectData("topic", xml.getBytes)
+
+    connectData.schema() shouldBe null
+    val value = connectData.value().asInstanceOf[java.util.LinkedHashMap[Any, Any]].asScalaRec
+    val expected = ListMap(
+      "order" -> List(
+        ListMap(
+          "id"        -> "1",
+          "item"      -> List("Item 1", ListMap("inner" -> "Item 2"), "Item 3"),
+          "different" -> "a",
+        ),
+        ListMap(
+          "id"   -> "2",
+          "item" -> List("Item 1", "Item 2", "Item 3"),
+        ),
+      ),
+      "other" -> "something else",
+    )
+
+    value shouldBe expected
+
+  }
+
+  // Recursively transform collections, and preserve Maps traversal order
+  implicit class JavaOps(xs: Any) {
+    def asScalaRec: Any =
+      xs match {
+        case xs: java.util.Map[_, _] =>
+          val entries = List.from(xs.entrySet().iterator().asScala).map(entry => entry.getKey -> entry.getValue)
+          ListMap.from(entries.map { case (k, v) => k -> v.asScalaRec })
+        case xs: java.util.Collection[_] => xs.asScala.map(_.asScalaRec)
+        case _ => xs
+      }
+
+  }
+}

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/converter/XmlConverterTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/converter/XmlConverterTest.scala
@@ -1,5 +1,6 @@
 package com.celonis.kafka.connect.ems.converter
 
+import org.apache.kafka.connect.data.SchemaAndValue
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -7,6 +8,10 @@ import scala.collection.immutable.ListMap
 import scala.jdk.CollectionConverters._
 
 class XmlConverterTest extends AnyFunSuite with Matchers {
+  test("it should return null schema and value for null input (tombstone messages)") {
+    converter.toConnectData("whatever", null) shouldBe SchemaAndValue.NULL
+  }
+
   test("it should convert xml") {
     val xml =
       """
@@ -26,7 +31,6 @@ class XmlConverterTest extends AnyFunSuite with Matchers {
         |</root>
         |""".stripMargin
 
-    val converter   = new XmlConverter
     val connectData = converter.toConnectData("topic", xml.getBytes)
 
     connectData.schema() shouldBe null
@@ -62,4 +66,6 @@ class XmlConverterTest extends AnyFunSuite with Matchers {
       }
 
   }
+
+  lazy val converter = new XmlConverter
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -225,6 +225,8 @@ object Dependencies {
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion
   lazy val jacksonModuleScala: ModuleID =
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
+  lazy val jacksonXml: ModuleID =
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % jacksonVersion
 
   lazy val nimbusJoseJwt = "com.nimbusds" % "nimbus-jose-jwt" % nimbusJoseJwtVersion
 
@@ -287,7 +289,7 @@ trait Dependencies {
                       nettyResolver,
                       nettyTransport,
   )
-  val jacksonDeps = Seq(jacksonCore, jacksonModuleScala, jacksonDatabind)
+  val jacksonDeps = Seq(jacksonCore, jacksonModuleScala, jacksonDatabind, jacksonXml)
 
   // Specific modules dependencies
   val emsSinkDeps: Seq[ModuleID] = (Seq(

--- a/src/e2e/resources/log4j.properties
+++ b/src/e2e/resources/log4j.properties
@@ -1,8 +1,0 @@
-# Root logger option
-log4j.rootLogger=INFO, stdout
-
-# Redirect log messages to console
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/src/e2e/resources/logback-test.xml
+++ b/src/e2e/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{ISO8601} %-5p [%C] [%M:%L] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/src/e2e/scala/com/celonis/kafka/connect/ems/XmlTests.scala
+++ b/src/e2e/scala/com/celonis/kafka/connect/ems/XmlTests.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2022 Celonis Ltd
+ */
+package com.celonis.kafka.connect.ems
+
+import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants._
+import com.celonis.kafka.connect.ems.parquet.extractParquetFromRequest
+import com.celonis.kafka.connect.ems.parquet.parquetReader
+import com.celonis.kafka.connect.ems.testcontainers.connect.EmsConnectorConfiguration
+import com.celonis.kafka.connect.ems.testcontainers.connect.EmsConnectorConfiguration.TOPICS_KEY
+import com.celonis.kafka.connect.ems.testcontainers.scalatest.KafkaConnectContainerPerSuite
+import com.celonis.kafka.connect.ems.testcontainers.scalatest.fixtures.connect.withConnector
+import com.celonis.kafka.connect.ems.testcontainers.scalatest.fixtures.mockserver.withMockResponse
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.mockserver.verify.VerificationTimes
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+
+class XmlTests extends AnyFunSuite with KafkaConnectContainerPerSuite with Matchers {
+
+  test("reads xml records") {
+    val sourceTopic = randomTopicName()
+    val emsTable    = randomEmsTable()
+
+    withMockResponse(emsRequestForTable(emsTable), mockEmsResponse) {
+
+      val emsConnector = new EmsConnectorConfiguration("ems")
+        .withConfig(TOPICS_KEY, sourceTopic)
+        .withConfig(ENDPOINT_KEY, proxyServerUrl)
+        .withConfig(AUTHORIZATION_KEY, "AppKey key")
+        .withConfig(TARGET_TABLE_KEY, emsTable)
+        .withConfig(COMMIT_RECORDS_KEY, 1)
+        .withConfig(COMMIT_SIZE_KEY, 1000000L)
+        .withConfig(COMMIT_INTERVAL_KEY, 3600000)
+        .withConfig(TMP_DIRECTORY_KEY, "/tmp/")
+        .withConfig(SHA512_SALT_KEY, "something")
+        .withConfig(FLATTENER_ENABLE_KEY, true)
+        .withConfig("value.converter", "com.celonis.kafka.connect.ems.converter.XmlConverter")
+
+      withConnector(emsConnector) {
+        val xml =
+          """
+            |<root>
+            |  <nested>
+            |    <a_bool>true</a_bool>
+            |    <an_int>3</an_int>
+            |    <many>first</many>
+            |    <many>second</many>
+            |    <mixed id="123">
+            |      <inner>abc</inner>
+            |    </mixed>
+            |  </nested>
+            |</root>
+            |""".stripMargin
+
+        withStringStringProducer(_.send(new ProducerRecord(sourceTopic, xml)))
+
+        eventually(timeout(60 seconds), interval(1 seconds)) {
+          mockServerClient.verify(emsRequestForTable(emsTable), VerificationTimes.once())
+          val status = kafkaConnectClient.getConnectorStatus(emsConnector.name)
+          status.tasks.head.state should be("RUNNING")
+        }
+
+        val httpRequests = mockServerClient.retrieveRecordedRequests(emsRequestForTable(emsTable))
+        val parquetFile  = extractParquetFromRequest(httpRequests.head)
+        val reader       = parquetReader(parquetFile)
+        val record       = reader.read()
+
+        // note how everything is a string
+        record.get("nested_a_bool").toString shouldBe "true"
+        record.get("nested_an_int").toString shouldBe "3"
+
+        // multiple instances of the same xml element are grouped in a sequence
+        record.get("nested_many").toString shouldBe """["first","second"]"""
+        record.get("nested_mixed_id").toString shouldBe "123"
+        record.get("nested_mixed_inner").toString shouldBe "abc"
+      }
+    }
+  }
+
+}

--- a/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/KafkaConnectContainerPerSuite.scala
+++ b/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/KafkaConnectContainerPerSuite.scala
@@ -158,6 +158,12 @@ trait KafkaConnectContainerPerSuite extends MockServerContainerPerSuite { this: 
       classOf[KafkaAvroSerializer],
     )(f)
 
+  def withStringStringProducer[A](f: KafkaProducer[String, String] => A): A =
+    withProducer(
+      classOf[StringSerializer],
+      classOf[StringSerializer],
+    )(f)
+
   def sendDummyAvroRecord(topic: String): Unit = {
     val valueSchema = SchemaBuilder.record("record").fields()
       .requiredString("a")


### PR DESCRIPTION
Add a new Converter that can be used to read from topics that contains XML data serialised as strings.

To use the converter, set the following option in the connector config:
```
value.converter=com.celonis.kafka.connect.ems.converter.XmlConverter
```