### PR TITLE
DP-1184: Connector hangs after a schema change

### DIFF
--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTask.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTask.scala
@@ -211,7 +211,7 @@ class EmsSinkTask extends SinkTask with StrictLogging {
   override def stop(): Unit = {
     (for {
       _ <- IO(logger.debug(s"[{}] EmsSinkTask.Stop", sinkName))
-      _ <- Option(writerManager).fold(IO(()))(_.close())
+      _ <- Option(writerManager).fold(IO(()))(_.close)
       _ <- Option(blockingExecutionContext).fold(IO(()))(ec => IO(ec.close()))
     } yield ()).attempt.unsafeRunSync() match {
       case Left(value) =>

--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTask.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTask.scala
@@ -124,8 +124,7 @@ class EmsSinkTask extends SinkTask with StrictLogging {
             _          <- writerManager.write(Record(avroRecord, metadata))
           } yield ()
         }
-      _ <- if (records.isEmpty)
-        writerManager.maybeUploadData()
+      _ <- if (records.isEmpty) writerManager.maybeUploadData
       else IO(())
     } yield ()
 

--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/WriterManager.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/WriterManager.scala
@@ -91,7 +91,6 @@ class WriterManager[F[_]](
         _            <- A.delay(fileCleanup.clean(file, state.offset))
         newWriter    <- A.delay(buildFn)
         _            <- A.delay(logger.debug("Creating a new writer for [{}]", writer.state.show))
-        _            <- setWriter(writer.state.topicPartition, newWriter)
       } yield CommitWriterResult(
         newWriter,
         TopicPartitionOffset(writer.state.topicPartition.topic,
@@ -127,7 +126,7 @@ class WriterManager[F[_]](
       _ <- writersRef.update(_ => newWritersMap)
     } yield ()
 
-  def close(): F[Unit] =
+  val close: F[Unit] =
     for {
       _          <- A.delay(logger.info(s"[{}] Received call to WriterManager.close()", sinkName))
       writers    <- writersRef.get.map(_.values.toList)

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/WriterManagerTests.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/WriterManagerTests.scala
@@ -126,7 +126,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       verify(writer2, times(1)).write(record2)
 
       // trigger the upload if applicable
-      manager.maybeUploadData().unsafeRunSync()
+      manager.maybeUploadData.unsafeRunSync()
       verifyNoInteractions(uploader)
     }
   }

--- a/src/e2e/scala/com/celonis/kafka/connect/ems/SchemaChangeTests.scala
+++ b/src/e2e/scala/com/celonis/kafka/connect/ems/SchemaChangeTests.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017-2022 Celonis Ltd
+ */
+package com.celonis.kafka.connect.ems
+
+import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants._
+import com.celonis.kafka.connect.ems.parquet.extractParquetFromRequest
+import com.celonis.kafka.connect.ems.parquet.parquetReader
+import com.celonis.kafka.connect.ems.testcontainers.connect.EmsConnectorConfiguration
+import com.celonis.kafka.connect.ems.testcontainers.connect.EmsConnectorConfiguration.TOPICS_KEY
+import com.celonis.kafka.connect.ems.testcontainers.scalatest.KafkaConnectContainerPerSuite
+import com.celonis.kafka.connect.ems.testcontainers.scalatest.fixtures.connect.withConnector
+import com.celonis.kafka.connect.ems.testcontainers.scalatest.fixtures.mockserver.withMockResponse
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.mockserver.verify.VerificationTimes
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+
+class SchemaChangeTests extends AnyFunSuite with KafkaConnectContainerPerSuite with Matchers {
+
+  test("schema change just after a flush") {
+    val sourceTopic  = randomTopicName()
+    val emsTable     = randomEmsTable()
+    val emsConnector = buildConnector(sourceTopic, emsTable)
+
+    withMockResponse(emsRequestForTable(emsTable), mockEmsResponse) {
+
+      withConnector(emsConnector) {
+
+        // After the insertion of the first two records, a flush happens because
+        // ems.connect.commit.records is set to 2
+        withStringStringProducer {
+          producer =>
+            producer.send(new ProducerRecord(sourceTopic, xml1))
+            producer.send(new ProducerRecord(sourceTopic, xml1))
+        }
+
+        eventually(timeout(60 seconds), interval(1 seconds)) {
+          mockServerClient.verify(emsRequestForTable(emsTable), VerificationTimes.once())
+        }
+
+        withStringStringProducer {
+          producer =>
+            producer.send(new ProducerRecord(sourceTopic, xml2))
+            producer.send(new ProducerRecord(sourceTopic, xml2))
+        }
+
+        eventually(timeout(10 seconds), interval(1 seconds)) {
+          mockServerClient.verify(emsRequestForTable(emsTable), VerificationTimes.exactly(2))
+        }
+      }
+    }
+  }
+
+  test("schema change when previous file has not been flushed yet") {
+    val sourceTopic  = randomTopicName()
+    val emsTable     = randomEmsTable()
+    val emsConnector = buildConnector(sourceTopic, emsTable)
+
+    withMockResponse(emsRequestForTable(emsTable), mockEmsResponse) {
+
+      withConnector(emsConnector) {
+
+        withStringStringProducer {
+          producer =>
+            producer.send(new ProducerRecord(sourceTopic, xml1))
+            producer.send(new ProducerRecord(sourceTopic, xml2))
+        }
+
+        eventually(timeout(10 seconds), interval(1 seconds)) {
+          mockServerClient.verify(emsRequestForTable(emsTable), VerificationTimes.once())
+        }
+
+        withStringStringProducer {
+          producer =>
+            producer.send(new ProducerRecord(sourceTopic, xml2))
+            producer.send(new ProducerRecord(sourceTopic, xml2))
+            producer.send(new ProducerRecord(sourceTopic, xml2))
+        }
+
+        eventually(timeout(10 seconds), interval(1 seconds)) {
+          mockServerClient.verify(emsRequestForTable(emsTable), VerificationTimes.exactly(3))
+        }
+      }
+    }
+  }
+
+  private def buildConnector(sourceTopic: String, emsTable: String): EmsConnectorConfiguration =
+    new EmsConnectorConfiguration("ems")
+      .withConfig(TOPICS_KEY, sourceTopic)
+      .withConfig(ENDPOINT_KEY, proxyServerUrl)
+      .withConfig(AUTHORIZATION_KEY, "AppKey key")
+      .withConfig(TARGET_TABLE_KEY, emsTable)
+      .withConfig(COMMIT_RECORDS_KEY, 2)
+      .withConfig(COMMIT_SIZE_KEY, 1000000L)
+      .withConfig(COMMIT_INTERVAL_KEY, 3600000)
+      .withConfig(TMP_DIRECTORY_KEY, "/tmp/")
+      .withConfig(SHA512_SALT_KEY, "something")
+      .withConfig(FLATTENER_ENABLE_KEY, true)
+      .withConfig("value.converter", "com.celonis.kafka.connect.ems.converter.XmlConverter")
+
+  lazy val xml1: String =
+    """
+      |<root>
+      |  <a>1</a>
+      |</root>
+      |""".stripMargin
+
+  lazy val xml2: String =
+    """
+      |<root>
+      |  <a>2</a>
+      |  <b>3</b>
+      |</root>
+      |""".stripMargin
+
+}


### PR DESCRIPTION
Fix DP-1184.
The fix ensures that, after a flush, the newly generated `Writer` is saved into the `WriterManager` state.

Tests:

- [x] Unit tests
- [x] E2E tests
- [ ] Manual E2E tests