### PR TITLE
Enable e2e tests on arm

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,8 +79,8 @@ object Dependencies {
 
     val jerseyCommonVersion = "2.35"
 
-    val testcontainersVersion   = "1.16.3"
-    val mockServerClientVersion = "5.5.4"
+    val testcontainersVersion   = "1.18.3"
+    val mockServerClientVersion = "5.15.0"
     val httpClientVersion       = "4.5.13"
     val json4sVersion           = "4.0.5"
     val jacksonVersion          = "2.14.2"

--- a/src/e2e/scala/com/celonis/kafka/connect/ems/ErrorPolicyTests.scala
+++ b/src/e2e/scala/com/celonis/kafka/connect/ems/ErrorPolicyTests.scala
@@ -7,13 +7,15 @@ import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants._
 import com.celonis.kafka.connect.ems.testcontainers.connect.EmsConnectorConfiguration
 import com.celonis.kafka.connect.ems.testcontainers.connect.EmsConnectorConfiguration.TOPICS_KEY
 import com.celonis.kafka.connect.ems.testcontainers.scalatest.KafkaConnectContainerPerSuite
-import com.celonis.kafka.connect.ems.testcontainers.scalatest.fixtures.connect.{withConnectionCut, withConnector}
+import com.celonis.kafka.connect.ems.testcontainers.scalatest.fixtures.connect.withConnectionCut
+import com.celonis.kafka.connect.ems.testcontainers.scalatest.fixtures.connect.withConnector
 import com.celonis.kafka.connect.ems.testcontainers.scalatest.fixtures.mockserver.withMockResponse
 import org.mockserver.verify.VerificationTimes
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.testcontainers.containers.output.OutputFrame.OutputType
-import org.testcontainers.containers.output.{OutputFrame, WaitingConsumer}
+import org.testcontainers.containers.output.OutputFrame
+import org.testcontainers.containers.output.WaitingConsumer
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.DurationInt

--- a/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/MockServerContainer.scala
+++ b/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/MockServerContainer.scala
@@ -46,8 +46,8 @@ class MockServerContainer(
 }
 
 object MockServerContainer {
-  private val dockerImage         = DockerImageName.parse("jamesdbloom/mockserver")
-  private val defaultTag          = "mockserver-5.5.4"
+  private val dockerImage         = DockerImageName.parse("mockserver/mockserver")
+  private val defaultTag          = "5.15.0"
   private val defaultNetworkAlias = "mockserver"
 
   def apply(

--- a/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/MockServerContainer.scala
+++ b/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/MockServerContainer.scala
@@ -28,7 +28,7 @@ class MockServerContainer(
   val networkAlias: String = defaultNetworkAlias,
 ) extends SingleContainer[JavaMockServerContainer] {
 
-  val port: Int = 1080
+  val port: Int = JavaMockServerContainer.PORT
 
   override val container: JavaMockServerContainer =
     new JavaMockServerContainer(dockerImage.withTag(dockerTag))
@@ -38,11 +38,8 @@ class MockServerContainer(
 
   class HostNetwork {
     def mockServerClient = new MockServerClient(container.getHost, container.getServerPort)
-
-    def mockServerUrl: String = s"https://$networkAlias:${container.getServerPort}"
   }
 
-  def mockServerUrl = s"https://$networkAlias:$port"
 }
 
 object MockServerContainer {

--- a/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/ToxiproxyContainer.scala
+++ b/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/ToxiproxyContainer.scala
@@ -35,9 +35,9 @@ class ToxiproxyContainer(
 
   container.withNetworkAliases(networkAlias)
 
-  def proxy(targetContainer: GenericContainer[_], port: Int, mappedPort: Int): Proxy = {
-    val upstream        = targetContainer.getNetworkAliases.get(0) + ":" + port
-    val listen          = "0.0.0.0:" + mappedPort
+  def proxy(targetContainer: GenericContainer[_], fromPort: Int, toPort: Int): Proxy = {
+    val upstream        = targetContainer.getNetworkAliases.get(0) + ":" + fromPort
+    val listen          = "0.0.0.0:" + toPort
     val toxiproxyClient = new ToxiproxyClient(container.getHost, container.getControlPort)
     toxiproxyClient.createProxy(upstream, listen, upstream)
   }

--- a/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/ToxiproxyContainer.scala
+++ b/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/ToxiproxyContainer.scala
@@ -17,6 +17,8 @@
 package com.celonis.kafka.connect.ems.testcontainers
 
 import com.celonis.kafka.connect.ems.testcontainers.ToxiproxyContainer.defaultTag
+import eu.rekawek.toxiproxy.Proxy
+import eu.rekawek.toxiproxy.ToxiproxyClient
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.{ ToxiproxyContainer => JavaToxiproxyContainer }
 import org.testcontainers.utility.DockerImageName
@@ -30,15 +32,20 @@ class ToxiproxyContainer(
 
   override val container: JavaToxiproxyContainer =
     new JavaToxiproxyContainer(dockerImage.withTag(dockerTag))
+
   container.withNetworkAliases(networkAlias)
 
-  def proxy(targetContainer: GenericContainer[_], port: Int): JavaToxiproxyContainer.ContainerProxy =
-    container.getProxy(targetContainer, port)
+  def proxy(targetContainer: GenericContainer[_], port: Int, mappedPort: Int): Proxy = {
+    val upstream        = targetContainer.getNetworkAliases.get(0) + ":" + port
+    val listen          = "0.0.0.0:" + mappedPort
+    val toxiproxyClient = new ToxiproxyClient(container.getHost, container.getControlPort)
+    toxiproxyClient.createProxy(upstream, listen, upstream)
+  }
 }
 
 object ToxiproxyContainer {
-  private val dockerImage = DockerImageName.parse("shopify/toxiproxy")
-  private val defaultTag  = "2.1.0"
+  private val dockerImage = DockerImageName.parse("ghcr.io/shopify/toxiproxy")
+  private val defaultTag  = "2.5.0"
 
   def apply(
     networkAlias: String,

--- a/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/KafkaConnectContainerPerSuite.scala
+++ b/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/KafkaConnectContainerPerSuite.scala
@@ -47,7 +47,7 @@ import scala.collection.mutable.ListBuffer
 
 trait KafkaConnectContainerPerSuite extends MockServerContainerPerSuite { this: TestSuite =>
 
-  val confluentPlatformVersion: String = sys.env.getOrElse("CONFLUENT_VERSION", "6.1.0")
+  val confluentPlatformVersion: String = sys.env.getOrElse("CONFLUENT_VERSION", "7.4.0")
 
   lazy val schemaRegistryInstance: Option[SchemaRegistryContainer] = schemaRegistryContainer()
 

--- a/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/MockServerContainerPerSuite.scala
+++ b/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/MockServerContainerPerSuite.scala
@@ -43,19 +43,21 @@ trait MockServerContainerPerSuite extends BeforeAndAfterAll with Eventually { th
   lazy val toxiproxyContainer: ToxiproxyContainer =
     ToxiproxyContainer("mockserver.celonis.cloud").withNetwork(network)
 
-  lazy val proxyServerUrl: String = s"https://${toxiproxyContainer.networkAlias}:8666"
+  lazy val proxyServerUrl: String =
+    s"https://${toxiproxyContainer.networkAlias}:$proxyPort"
 
-  println("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
-  println(proxyServerUrl)
+  lazy val proxyPort: Int =
+    toxiproxyContainer.container.getExposedPorts.get(1) // First exposed port after control port (should be 8666)
 
   implicit lazy val proxy: Proxy =
-    toxiproxyContainer.proxy(mockServerContainer.container, mockServerContainer.port, 8666)
+    toxiproxyContainer.proxy(mockServerContainer.container, mockServerContainer.port, proxyPort)
 
   implicit lazy val mockServerClient: MockServerClient = mockServerContainer.hostNetwork.mockServerClient
 
   override def beforeAll(): Unit = {
     mockServerContainer.start()
     toxiproxyContainer.start()
+    val _ = proxy
     super.beforeAll()
   }
 

--- a/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/MockServerContainerPerSuite.scala
+++ b/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/MockServerContainerPerSuite.scala
@@ -18,6 +18,7 @@ package com.celonis.kafka.connect.ems.testcontainers.scalatest
 
 import com.celonis.kafka.connect.ems.testcontainers.MockServerContainer
 import com.celonis.kafka.connect.ems.testcontainers.ToxiproxyContainer
+import eu.rekawek.toxiproxy.Proxy
 import org.mockserver.client.MockServerClient
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.TestSuite
@@ -27,7 +28,6 @@ import org.scalatest.time.Span
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.testcontainers.containers.Network
-import org.testcontainers.containers.{ ToxiproxyContainer => JavaToxiproxyContainer }
 
 trait MockServerContainerPerSuite extends BeforeAndAfterAll with Eventually { this: TestSuite =>
 
@@ -43,10 +43,13 @@ trait MockServerContainerPerSuite extends BeforeAndAfterAll with Eventually { th
   lazy val toxiproxyContainer: ToxiproxyContainer =
     ToxiproxyContainer("mockserver.celonis.cloud").withNetwork(network)
 
-  lazy val proxyServerUrl: String = s"https://${toxiproxyContainer.networkAlias}:${proxy.getOriginalProxyPort}"
+  lazy val proxyServerUrl: String = s"https://${toxiproxyContainer.networkAlias}:8666"
 
-  implicit lazy val proxy: JavaToxiproxyContainer.ContainerProxy =
-    toxiproxyContainer.proxy(mockServerContainer.container, mockServerContainer.port)
+  println("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+  println(proxyServerUrl)
+
+  implicit lazy val proxy: Proxy =
+    toxiproxyContainer.proxy(mockServerContainer.container, mockServerContainer.port, 8666)
 
   implicit lazy val mockServerClient: MockServerClient = mockServerContainer.hostNetwork.mockServerClient
 

--- a/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/fixtures/connect.scala
+++ b/test-common/src/main/scala/com/celonis/kafka/connect/ems/testcontainers/scalatest/fixtures/connect.scala
@@ -18,7 +18,8 @@ package com.celonis.kafka.connect.ems.testcontainers.scalatest.fixtures
 
 import com.celonis.kafka.connect.ems.testcontainers.connect.EmsConnectorConfiguration
 import com.celonis.kafka.connect.ems.testcontainers.connect.KafkaConnectClient
-import org.testcontainers.containers.ToxiproxyContainer
+import eu.rekawek.toxiproxy.Proxy
+import eu.rekawek.toxiproxy.model.ToxicDirection
 
 object connect {
 
@@ -26,12 +27,14 @@ object connect {
     testCode: => Any,
   )(
     implicit
-    proxy: ToxiproxyContainer.ContainerProxy): Unit = {
-    proxy.setConnectionCut(true)
+    proxy: Proxy): Unit = {
+    proxy.toxics.bandwidth("CUT_CONNECTION_DOWNSTREAM", ToxicDirection.DOWNSTREAM, 0)
+    proxy.toxics.bandwidth("CUT_CONNECTION_UPSTREAM", ToxicDirection.UPSTREAM, 0)
     try {
       val _ = testCode
     } finally {
-      proxy.setConnectionCut(false)
+      proxy.toxics.get("CUT_CONNECTION_DOWNSTREAM").remove()
+      proxy.toxics.get("CUT_CONNECTION_UPSTREAM").remove()
     }
   }
 


### PR DESCRIPTION
This PR upgrades some test dependencies in order to have integration and e2e tests runnable on a machine with ARM architecture.

### Details
- `testcontainer` dependency was upgraded from `1.16.x` to `1.18.x1
- `mockserver` was upgraded from `5.5.4` to `5.15.0`
- `toxiproxy` was upgraded from `2.1.0` to `2.5.0`
- confluent platform version was upgraded from `6.1.0` to `7.4.0`
- some refactor was needed to remove some deprecation warning when using `toxiproxy` proxies