### PR TITLE
Fix license report

### DIFF
--- a/project/PackagingTypePlugin.scala
+++ b/project/PackagingTypePlugin.scala
@@ -1,0 +1,11 @@
+// From https://github.com/sbt/sbt/issues/3618, to solve a problem where dumpLicenseReport
+// was not able to download info for https://repo1.maven.org/maven2/javax/ws/rs/javax.ws.rs-api/2.1.1/javax.ws.rs-api-2.1.1.${packaging.type}
+
+import sbt.*
+
+object PackagingTypePlugin extends AutoPlugin {
+  override val buildSettings = {
+    sys.props += "packaging.type" -> "jar"
+    Nil
+  }
+}


### PR DESCRIPTION
Create an sbt plugin to fix a weird error on generating license report (the url did not contain proper "jar" string)