### PR TITLE
WIP | DP-1632 make EmsUploadResponse.id and bucketId nullable

### DIFF
--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/EmsUploadResponse.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/EmsUploadResponse.scala
@@ -23,9 +23,9 @@ import org.http4s.circe.jsonOf
 import org.http4s.EntityDecoder
 
 case class EmsUploadResponse(
-  id:                    String,
+  id:                    Option[String],
   fileName:              String,
-  bucketId:              String,
+  bucketId:              Option[String],
   flushStatus:           String,
   clientId:              Option[String],
   fallbackVarcharLength: Option[Int],

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/EmsUploadResponseTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/EmsUploadResponseTest.scala
@@ -20,6 +20,7 @@ import io.circe.parser._
 import org.scalatest.EitherValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import cats.syntax.option._
 
 class EmsUploadResponseTest extends AnyFunSuite with Matchers with EitherValues {
 
@@ -41,13 +42,41 @@ class EmsUploadResponseTest extends AnyFunSuite with Matchers with EitherValues 
     val emsUploadResponse = decode[EmsUploadResponse](jsonResponse)
     emsUploadResponse.value should be(
       EmsUploadResponse(
-        id                    = "7513bc96-7003-480e-9b72-4e4ae8a7b05c",
+        id                    = "7513bc96-7003-480e-9b72-4e4ae8a7b05c".some,
         fileName              = "my-parquet-nice-file-name.parquet",
-        bucketId              = "6ca836f9-12e3-46f0-a5c4-20c9a309833d",
+        bucketId              = "6ca836f9-12e3-46f0-a5c4-20c9a309833d".some,
         flushStatus           = "NEW",
         clientId              = None,
         fallbackVarcharLength = Some(10000),
         upsertStrategy        = None,
+      ),
+    )
+
+  }
+
+  test("should decode emsUploadResponse with nullable id and bucketId") {
+    val jsonResponse =
+      """
+        |{
+        |  "id" : null,
+        |  "fileName" : "my-parquet-nice-file-name.parquet",
+        |  "flushStatus" : "NEW",
+        |  "clientId" : null,
+        |  "fallbackVarcharLength" : 10000,
+        |  "upsertStrategy" : null
+        |}
+        |""".stripMargin
+
+    val emsUploadResponse = decode[EmsUploadResponse](jsonResponse)
+    emsUploadResponse.value should be(
+      EmsUploadResponse(
+        id = None,
+        fileName = "my-parquet-nice-file-name.parquet",
+        bucketId = None,
+        flushStatus = "NEW",
+        clientId = None,
+        fallbackVarcharLength = Some(10000),
+        upsertStrategy = None,
       ),
     )
 

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/EmsUploaderTests.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/EmsUploaderTests.scala
@@ -59,7 +59,7 @@ class EmsUploaderTests extends AnyFunSuite with Matchers {
     val filePath         = UUID.randomUUID().toString + ".parquet"
     val fileContent      = Array[Byte](1, 2, 3, 4)
     val mapRef           = Ref.unsafe[IO, Map[String, Array[Byte]]](Map.empty)
-    val expectedResponse = EmsUploadResponse("id1", filePath, "b1", "new", "c1".some, None, None)
+    val expectedResponse = EmsUploadResponse("id1".some, filePath, "b1".some, "new", "c1".some, None, None)
     val responseQueueRef: Ref[IO, Queue[() => EmsUploadResponse]] =
       Ref.unsafe[IO, Queue[() => EmsUploadResponse]](Queue(() => expectedResponse))
     val serverResource =
@@ -117,7 +117,7 @@ class EmsUploaderTests extends AnyFunSuite with Matchers {
     val filePath         = UUID.randomUUID().toString + ".parquet"
     val fileContent      = Array[Byte](1, 2, 3, 4)
     val mapRef           = Ref.unsafe[IO, Map[String, Array[Byte]]](Map.empty)
-    val expectedResponse = EmsUploadResponse("id1", filePath, "b1", "new", "c1".some, None, None)
+    val expectedResponse = EmsUploadResponse("id1".some, filePath, "b1".some, "new", "c1".some, None, None)
     val responseQueueRef: Ref[IO, Queue[() => EmsUploadResponse]] =
       Ref.unsafe[IO, Queue[() => EmsUploadResponse]](Queue(() => expectedResponse))
     val serverResource =
@@ -180,7 +180,7 @@ class EmsUploaderTests extends AnyFunSuite with Matchers {
     val filePath         = UUID.randomUUID().toString + ".parquet"
     val fileContent      = Array[Byte](1, 2, 3, 4)
     val mapRef           = Ref.unsafe[IO, Map[String, Array[Byte]]](Map.empty)
-    val expectedResponse = EmsUploadResponse("id1", filePath, "b1", "new", "c1".some, None, None)
+    val expectedResponse = EmsUploadResponse("id1".some, filePath, "b1".some, "new", "c1".some, None, None)
     val responseQueueRef: Ref[IO, Queue[() => EmsUploadResponse]] =
       Ref.unsafe[IO, Queue[() => EmsUploadResponse]](Queue(() => expectedResponse))
     val proxyServerResource = ProxyServer.resource[IO](proxyPort, proxyAuth)
@@ -240,7 +240,7 @@ class EmsUploaderTests extends AnyFunSuite with Matchers {
     val filePath         = UUID.randomUUID().toString + ".parquet"
     val fileContent      = Array[Byte](1, 2, 3, 4)
     val mapRef           = Ref.unsafe[IO, Map[String, Array[Byte]]](Map.empty)
-    val expectedResponse = EmsUploadResponse("id1", filePath, "b1", "new", "c1".some, None, None)
+    val expectedResponse = EmsUploadResponse("id1".some, filePath, "b1".some, "new", "c1".some, None, None)
     val responseQueueRef: Ref[IO, Queue[() => EmsUploadResponse]] =
       Ref.unsafe[IO, Queue[() => EmsUploadResponse]](Queue(() => expectedResponse))
     val proxyServerResource = ProxyServer.resource[IO](proxyPort, proxyAuth)

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/UploadServer.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/UploadServer.scala
@@ -41,7 +41,7 @@ object UploadServer extends IOApp {
       table  <- Stream.eval(IO.fromTry(Try(args(3))))
       responseProvider = new EmsUploadResponseProvider[IO] {
         override def get: IO[EmsUploadResponse] =
-          IO(EmsUploadResponse(UUID.randomUUID().toString, "fn", "b1", "new", "c1".some, None, None))
+          IO(EmsUploadResponse(UUID.randomUUID().toString.some, "fn", "b1".some, "new", "c1".some, None, None))
       }
       fileService = new StoredFileService[IO](Path.fromNioPath(new File(folder).toPath))
       routes      = new MultipartHttpEndpoint[IO](fileService, responseProvider, auth, table).service.orNotFound

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/WriterManagerTests.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/WriterManagerTests.scala
@@ -328,9 +328,9 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
 
       when(writer2.shouldFlush).thenReturn(true)
       when(uploader.upload(UploadRequest.fromWriterState(writer2.state))).thenReturn(IO.pure(EmsUploadResponse(
-        "1",
+        "1".some,
         file2.getFileName.toString,
-        "b1",
+        "b1".some,
         "NEW",
         "c1".some,
         None,
@@ -401,7 +401,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       when(writer2.shouldFlush).thenReturn(true)
       when(
         uploader.upload(UploadRequest.fromWriterState(writer2.state)),
-      ).thenReturn(IO.pure(EmsUploadResponse("1", file2.getFileName.toString, "b1", "NEW", "c1".some, None, None)))
+      ).thenReturn(IO.pure(EmsUploadResponse("1".some, file2.getFileName.toString, "b1".some, "NEW", "c1".some, None, None)))
       manager.write(record2).unsafeRunSync()
 
       val retainedFile = new ParquetFileCleanupRename(fsImpl).renamedFile(file2, record2.metadata.offset)
@@ -470,7 +470,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       when(builder.writerFrom(record2)).thenReturn(writer2Next)
       when(
         uploader.upload(UploadRequest.fromWriterState(writer2.state)),
-      ).thenReturn(IO(EmsUploadResponse("1", file2.getFileName.toString, "b", "NEW", "c1".some, None, None)))
+      ).thenReturn(IO(EmsUploadResponse("1".some, file2.getFileName.toString, s"b".some, "NEW", "c1".some, None, None)))
       manager.write(record2).unsafeRunSync()
 
       verify(uploader, times(1)).upload(UploadRequest.fromWriterState(writer2.state))
@@ -517,7 +517,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       when(builder.writerFrom(any[Writer])).thenReturn(simpleWriter(simpleSchemaV1))
 
       when(uploader.upload(any[UploadRequest]))
-        .thenReturn(IO(EmsUploadResponse("1", file1.getFileName.toString, "b", "NEW", "c1".some, None, None)))
+        .thenReturn(IO(EmsUploadResponse("1".some, file1.getFileName.toString, "b".some, "NEW", "c1".some, None, None)))
 
       manager.write(record1).unsafeRunSync()
       manager.write(record2).unsafeRunSync()
@@ -585,7 +585,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       reset(uploader)
       when(
         uploader.upload(UploadRequest.fromWriterState(writer2.state)),
-      ).thenReturn(IO(EmsUploadResponse("1", file2.getFileName.toString, "b", "NEW", "c1".some, None, None)))
+      ).thenReturn(IO(EmsUploadResponse("1".some, file2.getFileName.toString, "b".some, "NEW", "c1".some, None, None)))
       val writer2Next = mock[Writer]
       when(builder.writerFrom(writer2)).thenReturn(writer2Next)
       manager.write(record2).unsafeRunSync()
@@ -653,7 +653,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
             s"${topicPartition.topic.value}_${topicPartition.partition.value}_${record2.metadata.offset.value}",
           ),
         ),
-      ).thenReturn(IO(EmsUploadResponse("1", file1.getFileName.toString, "b", "NEW", "c1".some, None, None)))
+      ).thenReturn(IO(EmsUploadResponse("1".some, file1.getFileName.toString, "b".some, "NEW", "c1".some, None, None)))
       manager.write(record2).unsafeRunSync()
 
       verify(uploader, times(1)).upload(
@@ -671,7 +671,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
             s"${topicPartition.topic.value}_${topicPartition.partition.value}_${record3.metadata.offset.value}",
           ),
         ),
-      ).thenReturn(IO(EmsUploadResponse("2", file2.getFileName.toString, "b", "NEW", "c1".some, None, None)))
+      ).thenReturn(IO(EmsUploadResponse("2".some, file2.getFileName.toString, "b".some, "NEW", "c1".some, None, None)))
 
       manager.write(record3).unsafeRunSync()
       verify(uploader, times(1)).upload(


### PR DESCRIPTION
### Description

Preparing for Streaming Ingestion: CBP responses with id & bucketId being nulls/empty should be accepted.

### Testing
- [x] Existing tests updated
- [x] a new test case for a response with empty ids