### PR TITLE
DP-1528 warn on duplicateRemovalOrderColumn not present in the schema

### DIFF
--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/EmsUploader.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/EmsUploader.scala
@@ -166,6 +166,8 @@ class EmsUploader[F[_]](
     ).flatMap(_ => A.raiseError(error))
 
   }
+
+  override def getOrderFieldName: Option[String] = this.maybeOrderFieldName
 }
 
 object EmsUploader {

--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/Uploader.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/Uploader.scala
@@ -15,6 +15,7 @@
  */
 
 package com.celonis.kafka.connect.ems.storage
+
 import cats.Show
 
 import java.nio.file.Path
@@ -38,6 +39,9 @@ object UploadRequest {
       ).mkString("_") + ".parquet",
     )
 }
+
 trait Uploader[F[_]] {
   def upload(request: UploadRequest): F[EmsUploadResponse]
+
+  def getOrderFieldName: Option[String]
 }

--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/WriterManager.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/storage/WriterManager.scala
@@ -28,6 +28,7 @@ import com.celonis.kafka.connect.ems.model.TopicPartitionOffset
 import com.typesafe.scalalogging.LazyLogging
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.syntax.EncoderOps
+import org.apache.avro.Schema
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 
 import java.nio.file.Files
@@ -42,34 +43,36 @@ import java.nio.file.Path
   * be safely shared without considerable overhead.
   */
 final class WriterManager[F[_]](
-  sinkName:      String,
-  uploader:      Uploader[F],
-  workingDir:    Path,
-  writerBuilder: WriterBuilder,
-  writersRef:    Ref[F, Map[TopicPartition, Writer]],
-  fileCleanup:   ParquetFileCleanup,
-  fileSystem:    FileSystemOperations,
-)(
-  implicit
-  A: Async[F],
-) extends StrictLogging {
+                                 sinkName: String,
+                                 uploader: Uploader[F],
+                                 workingDir: Path,
+                                 writerBuilder: WriterBuilder,
+                                 writersRef: Ref[F, Map[TopicPartition, Writer]],
+                                 fileCleanup: ParquetFileCleanup,
+                                 fileSystem: FileSystemOperations,
+                               )(
+                                 implicit
+                                 A: Async[F],
+                               ) extends StrictLogging {
 
   /** Uploads the data to EMS if the commit policy is met.
+    *
     * @return
     */
   val maybeUploadData: F[Unit] =
-    // The data is uploaded sequentially. We might want to parallelize the process
+  // The data is uploaded sequentially. We might want to parallelize the process
     for {
-      _       <- Async[F].delay(logger.debug(s"[{}] Received call to WriterManager.maybeUploadData", sinkName))
+      _ <- Async[F].delay(logger.debug(s"[{}] Received call to WriterManager.maybeUploadData", sinkName))
       writers <- writersRef.get.map(_.values.filter(_.shouldFlush).toList)
-      _       <- writers.traverse(w => commit(w, writerBuilder.writerFrom(w)))
+      _ <- writers.traverse(w => commit(w, writerBuilder.writerFrom(w)))
     } yield ()
 
   private case class CommitWriterResult(newWriter: Writer, offset: TopicPartitionOffset)
 
   /** Committing a file created by the writer, will result creating a new writer
+    *
     * @param writer
-    *   \- An instance of [[Writer]]
+    * \- An instance of [[Writer]]
     * @return
     */
   private def commit(writer: Writer, buildFn: => Writer): F[Option[CommitWriterResult]] = {
@@ -78,8 +81,10 @@ final class WriterManager[F[_]](
     if (state.records == 0) A.pure(None)
     else {
       for {
-        _       <- A.delay(writer.close())
-        file     = writer.state.file
+        _ <- A.delay(writer.close())
+        file = writer.state.file
+        _ = checkDuplicateRemovalOrderColumn(state.schema)
+
         fileSize = Files.size(file)
         _ <- A.delay(
           logger.info(
@@ -88,44 +93,55 @@ final class WriterManager[F[_]](
         )
         // we have a bug in how we keep track of the file size in the writer, it is updated only when there is a row flush
         stateWithSizeFixed = writer.state.copy(fileSize = fileSize)
-        uploadRequest      = UploadRequest.fromWriterState(stateWithSizeFixed)
-        _                 <- A.delay(logger.info(s"Request:${UploadRequest.show.show(uploadRequest)}"))
-        response          <- uploader.upload(uploadRequest)
-        _                 <- A.delay(logger.info(s"Received ${response.asJson.noSpaces} for uploading file:$file"))
-        _                 <- A.delay(fileCleanup.clean(file, state.lastOffset))
-        newWriter         <- A.delay(buildFn)
-        _                 <- A.delay(logger.debug("Creating a new writer for [{}]", writer.state.show))
-        _                 <- setWriter(writer.state.topicPartition, newWriter)
+        uploadRequest = UploadRequest.fromWriterState(stateWithSizeFixed)
+        _ <- A.delay(logger.info(s"Request:${UploadRequest.show.show(uploadRequest)}"))
+        response <- uploader.upload(uploadRequest)
+        _ <- A.delay(logger.info(s"Received ${response.asJson.noSpaces} for uploading file:$file"))
+        _ <- A.delay(fileCleanup.clean(file, state.lastOffset))
+        newWriter <- A.delay(buildFn)
+        _ <- A.delay(logger.debug("Creating a new writer for [{}]", writer.state.show))
+        _ <- setWriter(writer.state.topicPartition, newWriter)
       } yield CommitWriterResult(
         newWriter,
         TopicPartitionOffset(writer.state.topicPartition.topic,
-                             writer.state.topicPartition.partition,
-                             writer.state.lastOffset,
+          writer.state.topicPartition.partition,
+          writer.state.lastOffset,
         ),
       ).some
     }
   }
 
+  private def checkDuplicateRemovalOrderColumn(writerSchema: Schema): Unit = {
+    uploader.getOrderFieldName.foreach { orderFieldName =>
+      Option(writerSchema.getField(orderFieldName)) match {
+        case None =>
+          A.delay(logger.warn(s"Field configured as order field name, but not present in the schema. fieldName=$orderFieldName"))
+        case Some(_) =>
+      }
+    }
+  }
+
   /** When a partition is opened we cleanup the folder where the temp files are accumulating
+    *
     * @param partitions
-    *   \- A set of topic-partition tuples which the current task will own
+    * \- A set of topic-partition tuples which the current task will own
     */
   def open(partitions: Set[TopicPartition]): F[Unit] =
     for {
       writers <- writersRef.get.map(_.values.toList)
-      _       <- writers.traverse(w => A.delay(w.close()))
-      _       <- writersRef.update(_ => Map.empty)
-      _       <- partitions.toList.traverse(partition => A.delay(fileSystem.cleanup(workingDir, sinkName, partition)))
+      _ <- writers.traverse(w => A.delay(w.close()))
+      _ <- writersRef.update(_ => Map.empty)
+      _ <- partitions.toList.traverse(partition => A.delay(fileSystem.cleanup(workingDir, sinkName, partition)))
     } yield ()
 
   def close(partitions: List[TopicPartition]): F[Unit] =
     for {
       _ <- A.delay(logger.info(s"[{}] Received call to WriterManager.close(partitions):",
-                               sinkName,
-                               partitions.map(_.show).mkString(";"),
+        sinkName,
+        partitions.map(_.show).mkString(";"),
       ))
-      writersMap   <- writersRef.get
-      _            <- partitions.flatMap(writersMap.get).traverse(w => A.delay(w.close()))
+      writersMap <- writersRef.get
+      _ <- partitions.flatMap(writersMap.get).traverse(w => A.delay(w.close()))
       newWritersMap = writersMap -- partitions.toSet
       // do not cleanup the folders. on open partitions we do that.
       _ <- writersRef.update(_ => newWritersMap)
@@ -133,11 +149,11 @@ final class WriterManager[F[_]](
 
   val close: F[Unit] =
     for {
-      _          <- A.delay(logger.info(s"[{}] Received call to WriterManager.close()", sinkName))
-      writers    <- writersRef.get.map(_.values.toList)
+      _ <- A.delay(logger.info(s"[{}] Received call to WriterManager.close()", sinkName))
+      writers <- writersRef.get.map(_.values.toList)
       partitions <- writers.traverse(w => A.delay(w.close()).map(_ => w.state.topicPartition))
-      _          <- partitions.traverse(partition => A.delay(fileSystem.cleanup(workingDir, sinkName, partition)))
-      _          <- writersRef.update(_ => Map.empty)
+      _ <- partitions.traverse(partition => A.delay(fileSystem.cleanup(workingDir, sinkName, partition)))
+      _ <- writersRef.update(_ => Map.empty)
     } yield ()
 
   def write(record: Record): F[Unit] =
@@ -159,9 +175,9 @@ final class WriterManager[F[_]](
       latestWriter <-
         if (writer.shouldRollover(schema)) {
           for {
-            result      <- commit(writer, writerBuilder.writerFrom(record))
+            result <- commit(writer, writerBuilder.writerFrom(record))
             latestWriter = result.fold(writerBuilder.writerFrom(record))(_.newWriter)
-            _           <- setWriter(writer.state.topicPartition, latestWriter)
+            _ <- setWriter(writer.state.topicPartition, latestWriter)
           } yield latestWriter
         } else A.pure(writer)
       _ <- A.delay(latestWriter.write(record))
@@ -170,8 +186,9 @@ final class WriterManager[F[_]](
 
   /** Extracts the current offset for a given topic partition. If a topic partition does not have a committed offset, it
     * won't be returned to avoid Connect committing the offset
+    *
     * @param currentOffsets
-    *   \- A sequence of topic-partition tuples and their offset information
+    * \- A sequence of topic-partition tuples and their offset information
     * @return
     */
   def preCommit(currentOffsets: Map[TopicPartition, OffsetAndMetadata]): F[Map[TopicPartition, OffsetAndMetadata]] =
@@ -194,14 +211,14 @@ final class WriterManager[F[_]](
 
 object WriterManager extends LazyLogging {
   def from[F[_]](
-    config:     EmsSinkConfig,
-    sinkName:   String,
-    uploader:   Uploader[F],
-    writers:    Ref[F, Map[TopicPartition, Writer]],
-    fileSystem: FileSystemOperations,
-  )(
-    implicit
-    A: Async[F]): WriterManager[F] =
+                  config: EmsSinkConfig,
+                  sinkName: String,
+                  uploader: Uploader[F],
+                  writers: Ref[F, Map[TopicPartition, Writer]],
+                  fileSystem: FileSystemOperations,
+                )(
+                  implicit
+                  A: Async[F]): WriterManager[F] =
     new WriterManager(
       sinkName,
       uploader,

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/WriterManagerTests.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/WriterManagerTests.scala
@@ -285,6 +285,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val tp2      = TopicPartition(new Topic("B"), new Partition(3))
       val tp3      = TopicPartition(new Topic("C"), new Partition(0))
       val uploader = mock[Uploader[IO]]
+      when(uploader.getOrderFieldName).thenReturn("int_field".some)
       val builder  = mock[WriterBuilder]
 
       val manager =
@@ -351,6 +352,8 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val tp2      = TopicPartition(new Topic("B"), new Partition(3))
       val tp3      = TopicPartition(new Topic("C"), new Partition(0))
       val uploader = mock[Uploader[IO]]
+      when(uploader.getOrderFieldName).thenReturn("int_field".some)
+
       val builder  = mock[WriterBuilder]
 
       val manager = new WriterManager[IO](sink,
@@ -419,6 +422,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val tp2      = TopicPartition(new Topic("B"), new Partition(3))
       val tp3      = TopicPartition(new Topic("C"), new Partition(0))
       val uploader = mock[Uploader[IO]]
+      when(uploader.getOrderFieldName).thenReturn("int_field".some)
       val builder  = mock[WriterBuilder]
 
       val manager =
@@ -485,6 +489,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val sink     = "sinkA"
       val tp1      = TopicPartition(new Topic("topic"), new Partition(0))
       val uploader = mock[Uploader[IO]]
+      when(uploader.getOrderFieldName).thenReturn("int_field".some)
       val builder  = mock[WriterBuilder]
 
       val file1 = createEmptyFile(dir, "abc1")
@@ -533,6 +538,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val tp2      = TopicPartition(new Topic("B"), new Partition(3))
       val tp3      = TopicPartition(new Topic("C"), new Partition(0))
       val uploader = mock[Uploader[IO]]
+      when(uploader.getOrderFieldName).thenReturn("int_field".some)
       val builder  = mock[WriterBuilder]
 
       val manager =
@@ -583,6 +589,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       ex shouldBe exception
       verify(builder, times(0)).writerFrom(writer2)
       reset(uploader)
+      when(uploader.getOrderFieldName).thenReturn("int_field".some)
       when(
         uploader.upload(UploadRequest.fromWriterState(writer2.state)),
       ).thenReturn(IO(EmsUploadResponse("1", file2.getFileName.toString, "b", "NEW", "c1".some, None, None)))
@@ -630,6 +637,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val record3 = Record(struct3, RecordMetadata(topicPartition, new Offset(12)))
 
       val uploader = mock[Uploader[IO]]
+      when(uploader.getOrderFieldName).thenReturn("int_field".some)
       val builder = new WriterBuilderImpl(dir,
                                           sink,
                                           new DefaultCommitPolicy(10000, 10000, 2),
@@ -664,6 +672,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       )
 
       reset(uploader)
+      when(uploader.getOrderFieldName).thenReturn("int_field".some)
       when(
         uploader.upload(
           UploadRequest(

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/WriterManagerTests.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/storage/WriterManagerTests.scala
@@ -286,7 +286,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val tp3      = TopicPartition(new Topic("C"), new Partition(0))
       val uploader = mock[Uploader[IO]]
       when(uploader.getOrderFieldName).thenReturn("int_field".some)
-      val builder  = mock[WriterBuilder]
+      val builder = mock[WriterBuilder]
 
       val manager =
         new WriterManager[IO](sink, uploader, dir, builder, Ref.unsafe(Map.empty), ParquetFileCleanupDelete, fsOps)
@@ -354,7 +354,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val uploader = mock[Uploader[IO]]
       when(uploader.getOrderFieldName).thenReturn("int_field".some)
 
-      val builder  = mock[WriterBuilder]
+      val builder = mock[WriterBuilder]
 
       val manager = new WriterManager[IO](sink,
                                           uploader,
@@ -423,7 +423,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val tp3      = TopicPartition(new Topic("C"), new Partition(0))
       val uploader = mock[Uploader[IO]]
       when(uploader.getOrderFieldName).thenReturn("int_field".some)
-      val builder  = mock[WriterBuilder]
+      val builder = mock[WriterBuilder]
 
       val manager =
         new WriterManager[IO](sink, uploader, dir, builder, Ref.unsafe(Map.empty), ParquetFileCleanupDelete, fsOps)
@@ -490,7 +490,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val tp1      = TopicPartition(new Topic("topic"), new Partition(0))
       val uploader = mock[Uploader[IO]]
       when(uploader.getOrderFieldName).thenReturn("int_field".some)
-      val builder  = mock[WriterBuilder]
+      val builder = mock[WriterBuilder]
 
       val file1 = createEmptyFile(dir, "abc1")
       def simpleWriter(schema: Schema) = new SimpleDummyWriter(2, file1, schema, tp1)
@@ -539,7 +539,7 @@ class WriterManagerTests extends AnyFunSuite with Matchers with WorkingDirectory
       val tp3      = TopicPartition(new Topic("C"), new Partition(0))
       val uploader = mock[Uploader[IO]]
       when(uploader.getOrderFieldName).thenReturn("int_field".some)
-      val builder  = mock[WriterBuilder]
+      val builder = mock[WriterBuilder]
 
       val manager =
         new WriterManager[IO](sink, uploader, dir, builder, Ref.unsafe(Map.empty), ParquetFileCleanupDelete, fsOps)


### PR DESCRIPTION
### Description

Log a warning when uploading a file which schema does not contain a field configured as duplicateRemovalOrderColumn.

### Testing
- [x] existing unit tests updated
- [x] manual test with running connector and wrongly configured ordering field