### PR TITLE
DP-1710 | exclude kotlin classes from the assembled fatjar

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -294,6 +294,7 @@ object Settings extends Dependencies {
       "com.google.guava",
       "log4j",
       "org.apache.logging.log4j",
+      "kotlin",
     )
 
     def configureAssembly(): Project =


### PR DESCRIPTION
## Background
From recent exploratory testing we concluded that some of the classes included under the `kotlin` package were causing some eviction/loading problem when executed in Kafka Connect. When we would abruptly terminated a Parquet upload by killing the target server instance, we would incur into the mysterious error below rather than in a network related exception. 

> Exception in thread "OkHttp Dispatcher" java.lang.NoClassDefFoundError: Could not initialize class kotlin.internal.PlatformImplementationsKt` rather than some sort of network related exception.

## Scope of the change

This one liner change simply tweaks the build so that all classes under the `kotlin` package are excluded from the flatjar we ship as a Kafka Connect plugin.

