### PR TITLE
Fix a bug for a flattener when a schema that have a nested schema as …

### DIFF
--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/flatten/StructFlattener.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/flatten/StructFlattener.scala
@@ -87,7 +87,8 @@ private object StructFlattener {
       case head +: tail => value match {
           case value: Struct              => extractValue(value.get(head), Path(tail))
           case value: java.util.Map[_, _] => extractValue(value.get(head), Path(tail))
-          case _ => throw new RuntimeException(s"Field values can only be extracted from Structs and Maps")
+          case value if value == null => value
+          case _                      => throw new RuntimeException(s"Field values can only be extracted from Structs and Maps")
         }
       case _ => value
     }

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/config/ParquetConfigTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/config/ParquetConfigTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Celonis SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.celonis.kafka.connect.ems.config
 
 import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants._

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTaskObfuscationTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTaskObfuscationTest.scala
@@ -74,7 +74,7 @@ class EmsSinkTaskObfuscationTest extends AnyFunSuite with Matchers with WorkingD
         embedKafkaMetadata    = false,
         useInMemoryFileSystem = false,
         allowNullsAsPks       = false,
-        sinkPutTimeout = 4.minutes,
+        sinkPutTimeout        = 4.minutes,
       )
       val config = Map(
         ENDPOINT_KEY                     -> sinkConfig.url.toString,
@@ -94,7 +94,7 @@ class EmsSinkTaskObfuscationTest extends AnyFunSuite with Matchers with WorkingD
         FALLBACK_VARCHAR_LENGTH_KEY      -> sinkConfig.fallbackVarCharLengths.map(_.toString).orNull,
         OBFUSCATION_TYPE_KEY             -> "fix",
         OBFUSCATED_FIELDS_KEY            -> "b.x",
-        SINK_PUT_TIMEOUT_KEY -> 4.minutes.toMillis.toString,
+        SINK_PUT_TIMEOUT_KEY             -> 4.minutes.toMillis.toString,
       )
       task.start(config.asJava)
 


### PR DESCRIPTION
…a union with null

**Before**: 
For a message like:
```
"payload": {
    "a_map": null
}
```
When the schema is:
```
record A_Map {
  union { null, string } a_string = null;
}
protocol Paylod {
    union { null, A_Map } a_string = null;
}
```
Connector throws an error:
```
Field values can only be extracted from Structs and Maps
```
**After**:
No error, flattened the value of `payload_a_map_a_string` as `null`.