### PR TITLE
DP-2429 | Introduce incremental schema evolution

### DIFF
--- a/connector/src/main/java/com/celonis/kafka/connect/schema/SchemaEvolution.java
+++ b/connector/src/main/java/com/celonis/kafka/connect/schema/SchemaEvolution.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Celonis SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.celonis.kafka.connect.schema;
+
+import org.apache.kafka.connect.data.Schema;
+
+public interface SchemaEvolution {
+  Schema evolve(Schema currentSchema, Schema recordSchema) throws SchemaEvolutionException;
+}

--- a/connector/src/main/java/com/celonis/kafka/connect/schema/SchemaEvolutionException.java
+++ b/connector/src/main/java/com/celonis/kafka/connect/schema/SchemaEvolutionException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Celonis SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.celonis.kafka.connect.schema;
+
+public final class SchemaEvolutionException extends RuntimeException {
+  public SchemaEvolutionException(String message) {
+    super(message);
+  }
+}

--- a/connector/src/main/java/com/celonis/kafka/connect/schema/SchemaUtils.java
+++ b/connector/src/main/java/com/celonis/kafka/connect/schema/SchemaUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Celonis SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.celonis.kafka.connect.schema;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+import java.util.Optional;
+
+public class SchemaUtils {
+  public static SchemaBuilder withMetadata(SchemaBuilder builder, Schema schema) {
+    Optional.ofNullable(schema.parameters())
+        .filter(params -> !params.isEmpty())
+        .ifPresent(builder::parameters);
+
+    Optional.ofNullable(schema.name()).ifPresent(builder::name);
+    Optional.ofNullable(schema.doc()).ifPresent(builder::doc);
+    Optional.ofNullable(schema.defaultValue()).ifPresent(builder::defaultValue);
+    Optional.ofNullable(schema.version()).ifPresent(builder::version);
+
+    return builder;
+  }
+}

--- a/connector/src/main/java/com/celonis/kafka/connect/schema/StructSchemaAlignment.java
+++ b/connector/src/main/java/com/celonis/kafka/connect/schema/StructSchemaAlignment.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Celonis SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.celonis.kafka.connect.schema;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class StructSchemaAlignment {
+  /**
+   * Align an object to the schema accumulated by incrementally calling SchemaEvolution#evolve.
+   *
+   * <p>NOTE: this is needed in order to avoid the unnecessarily frequent flush of output Parquet
+   * files due JSON schema inference producing different records for what effectively is the same
+   * data (see `EmsOutputRecordSink#put)
+   *
+   * @param evolvedSchema the schema this value should align to. Must be a superset of the supplied
+   *     struct schema.
+   * @param value the current SinKRecord input struct
+   * @return a struct with the evolved schema
+   */
+  public static Struct alignTo(Schema evolvedSchema, Struct value) {
+    return (Struct) align(evolvedSchema, value);
+  }
+
+  private static Object align(Schema evolvedSchema, Object value) {
+    switch (evolvedSchema.type()) {
+      case ARRAY:
+        final var collection = (Collection<?>) value;
+        return collection.stream()
+            .map(item -> align(evolvedSchema.valueSchema(), item))
+            .collect(Collectors.toList());
+
+      case MAP:
+        final var map = (Map<?, ?>) value;
+        return map.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    entry -> align(evolvedSchema.keySchema(), entry.getKey()),
+                    entry -> align(evolvedSchema.valueSchema(), entry.getValue())));
+
+      case STRUCT:
+        final var structValue = (Struct) value;
+        if (structValue.schema() == evolvedSchema) return structValue;
+        final var newStruct = new Struct(evolvedSchema);
+
+        for (final var evolvedField : evolvedSchema.fields()) {
+          if (structValue.schema().field(evolvedField.name()) != null) {
+            newStruct.put(
+                evolvedField.name(),
+                align(evolvedField.schema(), structValue.get(evolvedField.name())));
+          }
+        }
+
+        return newStruct;
+      default:
+        return value;
+    }
+  }
+}

--- a/connector/src/main/java/com/celonis/kafka/connect/schema/StructSchemaEvolution.java
+++ b/connector/src/main/java/com/celonis/kafka/connect/schema/StructSchemaEvolution.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 Celonis SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.celonis.kafka.connect.schema;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+import java.util.Objects;
+
+/**
+ * StructSchemaEvolution is responsible for the recursively merging existing schema and schema from
+ * new record. And thus evolving the schema with each new record received from connector.
+ */
+public class StructSchemaEvolution implements SchemaEvolution {
+
+  /**
+   * Merge top level Kafka Connect Structs
+   *
+   * @param currentSchema existing schema, must be of type Struct
+   * @param recordSchema schema of new record, must be of type Struct
+   * @return Schema after merging existing and new schema recursively
+   */
+  @Override
+  public Schema evolve(Schema currentSchema, Schema recordSchema) throws SchemaEvolutionException {
+    if (currentSchema == recordSchema) return currentSchema;
+
+    // RecordTransformer ensures that the top level schema are of type Struct.
+    return mergeSchemas(null, currentSchema, recordSchema);
+  }
+
+  /**
+   * Merge a Kafka Connect Schemas
+   *
+   * @param fieldName current field name, `null` when the recursion starts
+   * @param currentSchema existing schema, (Accepted types MAP, ARRAY, STRUCT)
+   * @param recordSchema schema of new record, (Accepted types MAP, ARRAY, STRUCT)
+   * @return Schema after merging existing and new schemas recursively
+   */
+  private Schema mergeSchemas(String fieldName, Schema currentSchema, Schema recordSchema) {
+    // validationsFirst
+    validateSchemasTypes(fieldName, currentSchema, recordSchema);
+
+    switch (currentSchema.type()) {
+      case STRUCT:
+        return mergeStructs(currentSchema, recordSchema);
+      case ARRAY:
+        return SchemaBuilder.array(
+                mergeSchemas(fieldName, currentSchema.valueSchema(), recordSchema.valueSchema()))
+            .build();
+      case MAP:
+        var keySchema =
+            mergeSchemas(fieldName, currentSchema.keySchema(), recordSchema.keySchema());
+        var valueSchema =
+            mergeSchemas(fieldName, currentSchema.valueSchema(), recordSchema.valueSchema());
+        return SchemaBuilder.map(keySchema, valueSchema).build();
+      default:
+        return currentSchema;
+    }
+  }
+
+  private Schema mergeStructs(Schema currentSchema, Schema recordSchema)
+      throws SchemaEvolutionException {
+    SchemaBuilder result = SchemaUtils.withMetadata(SchemaBuilder.struct(), currentSchema);
+
+    // First currentSchemaFields
+    currentSchema.fields().stream()
+        .forEach(
+            currentSchemaField -> {
+              final var recordSchemaField = recordSchema.field(currentSchemaField.name());
+              if (recordSchemaField == null) {
+                // If not present in recordSchema, just add it
+                result.field(currentSchemaField.name(), currentSchemaField.schema());
+              } else {
+                // Recursively evolve otherwise
+                result.field(
+                    currentSchemaField.name(),
+                    mergeSchemas(
+                        currentSchemaField.name(),
+                        currentSchemaField.schema(),
+                        recordSchemaField.schema()));
+              }
+            });
+
+    // Just add remaining record schema fields as they are
+    recordSchema.fields().stream()
+        .filter(rf -> currentSchema.field(rf.name()) == null)
+        .forEach(rf -> result.field(rf.name(), rf.schema()));
+
+    return result.build();
+  }
+
+  private void validateSchemasTypes(String fieldName, Schema currentSchema, Schema recordSchema) {
+    if (bothPrimitives(currentSchema, recordSchema) && !sameLogicalType(currentSchema, recordSchema)
+        || !currentSchema.type().equals(recordSchema.type())) {
+
+      throw new SchemaEvolutionException(
+          String.format(
+              "New schema has field '%s' with a different type! "
+                  + "previous type: %s, current type: %s",
+              fieldName, currentSchema, recordSchema));
+    }
+  }
+
+  private boolean bothPrimitives(Schema s1, Schema s2) {
+    return s1.type().isPrimitive() && s2.type().isPrimitive();
+  }
+
+  private boolean sameLogicalType(Schema s1, Schema s2) {
+    return Objects.equals(s1.type(), s2.type())
+        && Objects.equals(s1.name(), s2.name())
+        && Objects.equals(s1.version(), s2.version())
+        && Objects.equals(s1.parameters(), s2.parameters());
+  }
+}

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/sink/EmsSinkConfiguratorTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/sink/EmsSinkConfiguratorTest.scala
@@ -78,15 +78,15 @@ class EmsSinkConfiguratorTest extends AnyFunSuite with Matchers {
 
   test(s"throws exception when $FALLBACK_VARCHAR_LENGTH_MAX is too big") {
     val props = Map(
-      "name" -> "ems",
-      EmsSinkConfigConstants.ENDPOINT_KEY -> "https://celonis.cloud",
-      EmsSinkConfigConstants.AUTHORIZATION_KEY -> "AppKey key",
-      EmsSinkConfigConstants.TARGET_TABLE_KEY -> "target-table",
-      EmsSinkConfigConstants.COMMIT_RECORDS_KEY -> "1",
-      EmsSinkConfigConstants.COMMIT_SIZE_KEY -> "1000000",
-      EmsSinkConfigConstants.COMMIT_INTERVAL_KEY -> "3600000",
-      EmsSinkConfigConstants.TMP_DIRECTORY_KEY -> "/tmp/",
-      EmsSinkConfigConstants.ERROR_POLICY_KEY -> "CONTINUE",
+      "name"                                             -> "ems",
+      EmsSinkConfigConstants.ENDPOINT_KEY                -> "https://celonis.cloud",
+      EmsSinkConfigConstants.AUTHORIZATION_KEY           -> "AppKey key",
+      EmsSinkConfigConstants.TARGET_TABLE_KEY            -> "target-table",
+      EmsSinkConfigConstants.COMMIT_RECORDS_KEY          -> "1",
+      EmsSinkConfigConstants.COMMIT_SIZE_KEY             -> "1000000",
+      EmsSinkConfigConstants.COMMIT_INTERVAL_KEY         -> "3600000",
+      EmsSinkConfigConstants.TMP_DIRECTORY_KEY           -> "/tmp/",
+      EmsSinkConfigConstants.ERROR_POLICY_KEY            -> "CONTINUE",
       EmsSinkConfigConstants.FALLBACK_VARCHAR_LENGTH_KEY -> "65001",
     ).asJava
 
@@ -94,5 +94,3 @@ class EmsSinkConfiguratorTest extends AnyFunSuite with Matchers {
     thrown.getMessage should include regex "^.*Must be greater than 0 and smaller or equal than 65000.*$"
   }
 }
-
-

--- a/connector/src/test/scala/com/celonis/kafka/connect/schema/StructSchemaAlignmentTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/schema/StructSchemaAlignmentTest.scala
@@ -1,0 +1,191 @@
+package com.celonis.kafka.connect.schema
+
+import com.celonis.kafka.connect.schema.StructSchemaAlignmentTest.Scenario
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Struct
+import org.scalatest.Inside
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import scala.jdk.CollectionConverters._
+
+class StructSchemaAlignmentTest extends AnyFunSuite with Matchers with Inside {
+  for (
+    scenario <- Seq(
+      Scenario.nestedStruct,
+      Scenario.structInArray,
+      Scenario.nestedArray,
+      Scenario.nestedMap,
+      Scenario.structInMap,
+    )
+  ) {
+    test(scenario.label) {
+      StructSchemaAlignment.alignTo(scenario.superSchema, scenario.inputValue) shouldEqual scenario.expectedAlignedValue
+    }
+  }
+}
+object StructSchemaAlignmentTest {
+  final case class Scenario(label: String, superSchema: Schema, inputValue: Struct, expectedAlignedValue: Struct) {
+    override def toString: String = label
+  }
+
+  object Scenario {
+    val nestedStruct: Scenario = {
+      val superSchema: Schema = SchemaBuilder.struct.field("a", Schema.INT64_SCHEMA).field(
+        "b",
+        SchemaBuilder.struct.field("b1", Schema.STRING_SCHEMA).field("b2", Schema.OPTIONAL_INT64_SCHEMA).build,
+      ).build
+
+      val subSchema: Schema = SchemaBuilder.struct.field("b1", Schema.STRING_SCHEMA).build
+
+      val schema: Schema = SchemaBuilder.struct.field("a", Schema.INT64_SCHEMA).field("b", subSchema).build
+
+      val struct    = new Struct(schema)
+      val subStruct = new Struct(subSchema)
+
+      subStruct.put("b1", "hello")
+      struct.put("a", 1L)
+      struct.put("b", subStruct)
+
+      val expected  = new Struct(superSchema)
+      val expectedB = new Struct(superSchema.field("b").schema)
+      expectedB.put("b1", "hello")
+
+      expected.put("a", 1L)
+      expected.put("b", expectedB)
+
+      Scenario(
+        label                = "aligns nested struct values to the super-schema",
+        superSchema          = superSchema,
+        inputValue           = struct,
+        expectedAlignedValue = expected,
+      )
+    }
+
+    val structInArray: Scenario = {
+      val superSchema: Schema = SchemaBuilder.struct.field("a", Schema.INT64_SCHEMA).field(
+        "b",
+        SchemaBuilder.array(SchemaBuilder.struct.field("b1", Schema.STRING_SCHEMA).field("b2",
+                                                                                         Schema.OPTIONAL_INT64_SCHEMA,
+        ).build).build,
+      ).build
+
+      val subSchema: Schema = SchemaBuilder.struct.field("b1", Schema.STRING_SCHEMA).build
+
+      val schema: Schema =
+        SchemaBuilder.struct.field("a", Schema.INT64_SCHEMA).field("b", SchemaBuilder.array(subSchema).build).build
+
+      val struct:    Struct = new Struct(schema)
+      val subStruct: Struct = new Struct(subSchema)
+
+      subStruct.put("b1", "hello")
+      struct.put("a", 1L)
+      struct.put("b", List(subStruct).asJava)
+
+      val expected:  Struct = new Struct(superSchema)
+      val expectedB: Struct = new Struct(superSchema.field("b").schema.valueSchema)
+      expectedB.put("b1", "hello")
+
+      expected.put("a", 1L)
+      expected.put("b", List(expectedB).asJava)
+
+      Scenario(
+        label                = "aligns arrays of structs to the super-schema",
+        superSchema          = superSchema,
+        inputValue           = struct,
+        expectedAlignedValue = expected,
+      )
+    }
+
+    val nestedArray: Scenario = {
+      val superSchema = SchemaBuilder.struct.field("a", Schema.INT64_SCHEMA).field(
+        "b",
+        SchemaBuilder.array(SchemaBuilder.array(Schema.STRING_SCHEMA).build).build,
+      ).build
+
+      val subSchema = SchemaBuilder.struct.field("b", superSchema.field("b").schema)
+
+      val struct = new Struct(subSchema)
+      struct.put("b", List(List("a", "b", "c").asJava, List("x", "y", "z").asJava).asJava)
+
+      val expected = new Struct(superSchema)
+      expected.put("b", struct.getArray("b"))
+
+      Scenario(
+        label                = "aligns nested arrays to the super-schema",
+        superSchema          = superSchema,
+        inputValue           = struct,
+        expectedAlignedValue = expected,
+      )
+    }
+
+    val nestedMap: Scenario = {
+      val superSchema = SchemaBuilder.struct.field("a", Schema.INT64_SCHEMA).field(
+        "b",
+        SchemaBuilder.map(SchemaBuilder.string, SchemaBuilder.array(Schema.STRING_SCHEMA).build).build,
+      ).build
+
+      val subSchema = SchemaBuilder.struct.field("b", superSchema.field("b").schema)
+
+      val struct = new Struct(subSchema)
+      struct.put("b", Map("abc" -> List("a", "b", "c").asJava, "xyz" -> List("x", "y", "z").asJava).asJava)
+
+      val expected = new Struct(superSchema)
+      expected.put("b", struct.getMap("b"))
+
+      Scenario(
+        label                = "aligns an array nested into a map to the super-schema",
+        superSchema          = superSchema,
+        inputValue           = struct,
+        expectedAlignedValue = expected,
+      )
+    }
+
+    val structInMap: Scenario = {
+      val superSchema = SchemaBuilder.struct.field("a", Schema.INT64_SCHEMA).field(
+        "b",
+        SchemaBuilder.map(
+          SchemaBuilder.struct.field("b0", Schema.STRING_SCHEMA).build,
+          SchemaBuilder.struct.field("b1", Schema.STRING_SCHEMA).field("b2", Schema.OPTIONAL_INT64_SCHEMA).build,
+        ).build,
+      ).build
+
+      val keySubSchema   = SchemaBuilder.struct.field("b0", Schema.STRING_SCHEMA).build
+      val valueSubSchema = SchemaBuilder.struct.field("b1", Schema.STRING_SCHEMA).build
+
+      val schema = SchemaBuilder.struct.field("a", Schema.INT64_SCHEMA).field(
+        "b",
+        SchemaBuilder.map(keySubSchema, valueSubSchema).build,
+      ).build
+
+      val struct       = new Struct(schema)
+      val keySubStruct = new Struct(keySubSchema)
+      keySubStruct.put("b0", "hello-key")
+
+      val valueSubStruct = new Struct(valueSubSchema)
+      valueSubStruct.put("b1", "hello-key")
+
+      struct.put("a", 1L)
+      struct.put("b", Map(keySubStruct -> valueSubStruct).asJava)
+
+      val expected = new Struct(superSchema)
+
+      val expectedBKey = new Struct(superSchema.field("b").schema.keySchema)
+      expectedBKey.put("b0", keySubStruct.get("b0"))
+      val expectedBValue = new Struct(superSchema.field("b").schema.valueSchema)
+      expectedBValue.put("b1", valueSubStruct.get("b1"))
+
+      expected.put("a", 1L)
+      expected.put("b", Map(expectedBKey -> expectedBValue).asJava)
+
+      Scenario(
+        label                = "aligns maps of structs to the super-schema",
+        superSchema          = superSchema,
+        inputValue           = struct,
+        expectedAlignedValue = expected,
+      )
+    }
+
+  }
+
+}

--- a/connector/src/test/scala/com/celonis/kafka/connect/schema/StructSchemaEvolutionTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/schema/StructSchemaEvolutionTest.scala
@@ -1,0 +1,570 @@
+/*
+ * Copyright 2023 Celonis SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.celonis.kafka.connect.schema;
+
+import com.celonis.kafka.connect.schema.StructSchemaEvolutionTest.LogicalTypeScenario
+import io.confluent.connect.avro.AvroData
+import org.apache.avro.LogicalTypes
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.scalatest.Inside
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
+import scala.util.Failure
+import scala.util.Try
+
+class StructSchemaEvolutionTest extends AnyFunSuite with Matchers with Inside {
+  private val schemaEv = new StructSchemaEvolution();
+
+  test("schema evolution with common primitive fields") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field("a_string", Schema.STRING_SCHEMA)
+        .field("an_int", Schema.INT64_SCHEMA)
+        .build()
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field("a_string", Schema.STRING_SCHEMA)
+        .field("an_int", Schema.INT64_SCHEMA)
+        .build()
+
+    val expectedResult =
+      SchemaBuilder.struct()
+        .field("a_string", Schema.STRING_SCHEMA)
+        .field("an_int", Schema.INT64_SCHEMA)
+        .build()
+
+    val result = schemaEv.evolve(currentSchema, recordSchema)
+
+    expectedResult shouldEqual result
+  }
+
+  test("throws exception For Different SchemaTypes with same name") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field("a_string", Schema.STRING_SCHEMA)
+        .field("an_int", Schema.INT64_SCHEMA)
+        .build();
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field("a_string", Schema.INT64_SCHEMA)
+        .field("an_int", Schema.INT64_SCHEMA)
+        .build();
+
+    val result = Try(schemaEv.evolve(currentSchema, recordSchema))
+
+    inside(result) {
+      case Failure(exception) =>
+        exception.isInstanceOf[SchemaEvolutionException] shouldBe true
+        exception.getMessage.contains("New schema has field 'a_string' with a different type!") shouldBe true
+    }
+  }
+  test("schema evolution with empty current fields") {
+    val currentSchema = SchemaBuilder.struct().name("test-schema").version(1).build();
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field("a_string", Schema.STRING_SCHEMA)
+        .field("an_int", Schema.INT64_SCHEMA)
+        .build()
+
+    val expectedResult =
+      SchemaBuilder.struct()
+        .name("test-schema")
+        .version(1)
+        .field("a_string", Schema.STRING_SCHEMA)
+        .field("an_int", Schema.INT64_SCHEMA)
+        .build()
+
+    val result = schemaEv.evolve(currentSchema, recordSchema);
+
+    result shouldEqual expectedResult
+  }
+  test("SchemaEvolutionWithEmptyRecordFields") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field("a_string", Schema.STRING_SCHEMA)
+        .field("an_int", Schema.INT64_SCHEMA)
+        .build()
+    val recordSchema = SchemaBuilder.struct().build()
+
+    val expectedResult =
+      SchemaBuilder.struct()
+        .field("a_string", Schema.STRING_SCHEMA)
+        .field("an_int", Schema.INT64_SCHEMA)
+        .build()
+
+    schemaEv.evolve(currentSchema, recordSchema) shouldEqual expectedResult
+  }
+
+  test("SchemaEvolutionWithCommonStructFields") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_2",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .build()
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_2",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .build()
+
+    val expectedResult =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_2",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .build();
+
+    schemaEv.evolve(currentSchema, recordSchema) shouldEqual expectedResult
+  }
+  test("SchemaEvolutionWithAdditionalRecordFields") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .build()
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct()
+            .field("a_string", Schema.STRING_SCHEMA)
+            .field("an_int", Schema.INT64_SCHEMA)
+            .field("a_string_2", Schema.STRING_SCHEMA)
+            .build(),
+        )
+        .build()
+
+    val expectedResult =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct()
+            .field("a_string", Schema.STRING_SCHEMA)
+            .field("an_int", Schema.INT64_SCHEMA)
+            .field("a_string_2", Schema.STRING_SCHEMA)
+            .build(),
+        )
+        .build()
+
+    schemaEv.evolve(currentSchema, recordSchema) shouldEqual expectedResult
+  }
+  test("SchemaEvolutionWithAdditionalStructRecordField") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .build()
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_2",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_3",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .build()
+
+    val expectedResult =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_2",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_3",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .build()
+
+    val result = schemaEv.evolve(currentSchema, recordSchema);
+
+    for (field <- expectedResult.fields().asScala) {
+      field.schema() shouldEqual result.field(field.name()).schema()
+    }
+
+  }
+  test("SchemaEvolutionWithAdditionalStructCurrentField") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_2",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_3",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .build();
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_4",
+          SchemaBuilder.struct().field("an_int", Schema.INT64_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_3",
+          SchemaBuilder.struct()
+            .field("a_string", Schema.STRING_SCHEMA)
+            .field("an_int", Schema.INT64_SCHEMA)
+            .build(),
+        )
+        .build();
+
+    val expectedResult =
+      SchemaBuilder.struct()
+        .field(
+          "a_struct",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_2",
+          SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_4",
+          SchemaBuilder.struct().field("an_int", Schema.INT64_SCHEMA).build(),
+        )
+        .field(
+          "a_struct_3",
+          SchemaBuilder.struct()
+            .field("a_string", Schema.STRING_SCHEMA)
+            .field("an_int", Schema.INT64_SCHEMA)
+            .build(),
+        )
+        .build();
+
+    val result = schemaEv.evolve(currentSchema, recordSchema);
+    for (field <- expectedResult.fields().asScala) {
+      field.schema() shouldEqual result.field(field.name()).schema()
+    }
+  }
+  test("ArrayEvolutionWithDifferentStructFields") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field(
+          "topStruct",
+          SchemaBuilder.array(SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA)),
+        )
+        .build()
+
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field(
+          "topStruct",
+          SchemaBuilder.array(SchemaBuilder.struct().field("an_int", Schema.INT64_SCHEMA)),
+        )
+        .build()
+
+    val result = schemaEv.evolve(currentSchema, recordSchema);
+    val expectedSchema =
+      SchemaBuilder.struct()
+        .field(
+          "topStruct",
+          SchemaBuilder.array(
+            SchemaBuilder.struct()
+              .field("a_string", Schema.STRING_SCHEMA)
+              .field("an_int", Schema.INT64_SCHEMA)
+              .build(),
+          )
+            .build(),
+        )
+        .build()
+
+    result shouldEqual expectedSchema
+  }
+  test("RecursiveArrayEvolutionWithDifferentStructFields") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field(
+          "topStruct",
+          SchemaBuilder.array(
+            SchemaBuilder.array(
+              SchemaBuilder.struct().field("a_string", Schema.STRING_SCHEMA),
+            ),
+          ),
+        )
+        .build()
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field(
+          "topStruct",
+          SchemaBuilder.array(
+            SchemaBuilder.array(
+              SchemaBuilder.struct().field("an_int", Schema.INT64_SCHEMA),
+            ),
+          ),
+        )
+        .build()
+
+    val expectedSchema =
+      SchemaBuilder.struct()
+        .field(
+          "topStruct",
+          SchemaBuilder.array(
+            SchemaBuilder.array(
+              SchemaBuilder.struct()
+                .field("a_string", Schema.STRING_SCHEMA)
+                .field("an_int", Schema.INT64_SCHEMA)
+                .build(),
+            )
+              .build(),
+          )
+            .build(),
+        )
+        .build()
+
+    schemaEv.evolve(currentSchema, recordSchema) shouldEqual expectedSchema
+  }
+  test("MapEvolutionWithDifferentStructFields") {
+    val currentSchema =
+      SchemaBuilder.struct()
+        .field(
+          "topStruct",
+          SchemaBuilder.map(
+            SchemaBuilder.struct().field("key_string", Schema.STRING_SCHEMA),
+            SchemaBuilder.struct().field("value_string", Schema.STRING_SCHEMA),
+          ),
+        )
+        .build()
+    val recordSchema =
+      SchemaBuilder.struct()
+        .field(
+          "topStruct",
+          SchemaBuilder.map(
+            SchemaBuilder.struct().field("key_int", Schema.INT64_SCHEMA),
+            SchemaBuilder.struct().field("value_int", Schema.INT64_SCHEMA),
+          ),
+        )
+        .build()
+
+    val expectedSchema =
+      SchemaBuilder.struct()
+        .field(
+          "topStruct",
+          SchemaBuilder.map(
+            SchemaBuilder.struct()
+              .field("key_string", Schema.STRING_SCHEMA)
+              .field("key_int", Schema.INT64_SCHEMA)
+              .build(),
+            SchemaBuilder.struct()
+              .field("value_string", Schema.STRING_SCHEMA)
+              .field("value_int", Schema.INT64_SCHEMA)
+              .build(),
+          )
+            .build(),
+        )
+        .build()
+
+    schemaEv.evolve(currentSchema, recordSchema) shouldEqual expectedSchema
+  }
+  test("subSchemaMatchesItsPreviousVersion") {
+    Seq("x", "y", "z").foreach { field =>
+      val schema1 =
+        SchemaBuilder.struct()
+          .field("x", Schema.INT32_SCHEMA)
+          .field("y", Schema.INT32_SCHEMA)
+          .field("z", Schema.INT32_SCHEMA)
+          .build()
+
+      val schema2 = SchemaBuilder.struct().field(field, Schema.INT32_SCHEMA).build()
+
+      schemaEv.evolve(schema1, schema2) shouldEqual schema1
+    }
+  }
+  test("fieldOrderIsPreserved") {
+    val prefix1 = "s1_"
+    val prefix2 = "s2_"
+
+    val schema1 = withAToZFields(SchemaBuilder.struct(), prefix1).build()
+    val schema2 = withAToZFields(SchemaBuilder.struct(), prefix2).build()
+
+    val expected =
+      withAToZFields(withAToZFields(SchemaBuilder.struct(), prefix1), prefix2).build()
+
+    schemaEv.evolve(schema1, schema2) shouldEqual expected
+
+  }
+
+  def withAToZFields(b: SchemaBuilder, prefix: String): SchemaBuilder = {
+    for (char <- 'a' to 'z') {
+      b.field(prefix + char, Schema.BYTES_SCHEMA);
+    }
+    b
+  }
+
+  test("avroLogicalTypeAwareness") {
+    for (
+      scenario <- Seq(
+        LogicalTypeScenario.bytesNeqDecimal,
+        LogicalTypeScenario.decimalPrecisionScale,
+        LogicalTypeScenario.date,
+        LogicalTypeScenario.timestamp,
+        LogicalTypeScenario.time,
+      )
+    ) {
+      val fieldName = "some-field";
+
+      val previousSchema =
+        SchemaBuilder.struct().field(fieldName, scenario.previousSchema).build()
+
+      val currentSchema =
+        SchemaBuilder.struct().field(fieldName, scenario.currentSchema).build()
+
+      for (
+        (previous, current) <- Map(
+          previousSchema -> currentSchema,
+          currentSchema  -> previousSchema,
+        )
+      ) {
+
+        val result = Try(schemaEv.evolve(previous, current))
+        inside(result) {
+          case Failure(exception) =>
+            exception.isInstanceOf[SchemaEvolutionException] shouldBe true
+            if (scenario.current.getLogicalType != null) {
+              exception.getMessage.contains(scenario.currentSchema.name()) shouldBe true
+            }
+            if (scenario.previous.getLogicalType != null) {
+              exception.getMessage.contains(scenario.previousSchema.name()) shouldBe true
+            }
+        }
+
+      }
+    }
+  }
+}
+object StructSchemaEvolutionTest {
+  case class LogicalTypeScenario(
+    label:    String,
+    previous: org.apache.avro.Schema,
+    current:  org.apache.avro.Schema,
+  ) {
+
+    private val converter = new AvroData(100);
+
+    override def toString: String = label
+
+    def previousSchema: Schema = converter.toConnectSchema(previous)
+
+    def currentSchema: Schema = converter.toConnectSchema(current)
+  }
+
+  object LogicalTypeScenario {
+    private def avroBuilder(): org.apache.avro.SchemaBuilder.TypeBuilder[org.apache.avro.Schema] =
+      org.apache.avro.SchemaBuilder.builder()
+
+    val bytesNeqDecimal: LogicalTypeScenario = {
+
+      val logicalType = LogicalTypes.decimal(5, 2).addToSchema(avroBuilder().bytesType())
+
+      LogicalTypeScenario(
+        label    = "BYTES != AVRO Decimal(5,3)",
+        previous = avroBuilder().bytesType(),
+        current  = avroBuilder().`type`(logicalType),
+      )
+    }
+
+    val decimalPrecisionScale: LogicalTypeScenario = {
+      val logicalType5_2 = LogicalTypes.decimal(5, 2).addToSchema(avroBuilder().bytesType())
+      val logicalType5_3 = LogicalTypes.decimal(5, 3).addToSchema(avroBuilder().bytesType())
+      val decimal5_2     = avroBuilder().`type`(logicalType5_2)
+      val decimal5_3     = avroBuilder().`type`(logicalType5_3)
+      LogicalTypeScenario(
+        label    = "AVRO Decimal(5,2) != AVRO Decimal(5,3)",
+        previous = decimal5_2,
+        current  = decimal5_3,
+      )
+    }
+
+    val date: LogicalTypeScenario = {
+      val logicalType =
+        LogicalTypes.date().addToSchema(avroBuilder().intType()) // days since epoch
+
+      val aDate = avroBuilder().`type`(logicalType)
+      LogicalTypeScenario(
+        label    = "INT != AVRO DATE",
+        previous = avroBuilder().intType(),
+        current  = aDate,
+      )
+    }
+
+    val timestamp: LogicalTypeScenario = {
+      val logicalType = LogicalTypes.timestampMillis().addToSchema(avroBuilder().longType())
+
+      val ts = avroBuilder().`type`(logicalType)
+      LogicalTypeScenario(
+        label    = "LONG != AVRO TIMESTAMP",
+        previous = avroBuilder().longType(),
+        current  = ts,
+      )
+    }
+
+    val time: LogicalTypeScenario = {
+      val logicalType = LogicalTypes.timeMillis().addToSchema(avroBuilder().intType())
+
+      val t = avroBuilder().`type`(logicalType)
+
+      LogicalTypeScenario(
+        label    = "INT != AVRO TIME",
+        previous = avroBuilder().intType(),
+        current  = t,
+      )
+    }
+
+  }
+}

--- a/connector/src/test/scala/com/celonis/kafka/connect/transform/RecordTransformerTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/transform/RecordTransformerTest.scala
@@ -36,15 +36,14 @@ class RecordTransformerTest extends AnyFunSuite with Matchers {
   test("evolves target schema and aligns sunk record value to it") {
     val value1 = Map[String, Any](
       "a_string" -> "hello",
-      "an_int" -> 1,
-      "a_float" -> 1.5,
+      "an_int"   -> 1,
+      "a_float"  -> 1.5,
     ).asJava
 
     val value2 = Map[String, Any](
       "a_string" -> "hello again",
-      //other fields omitted
+      // other fields omitted
     ).asJava
-
 
     val transformer =
       RecordTransformer.fromConfig(
@@ -54,23 +53,53 @@ class RecordTransformerTest extends AnyFunSuite with Matchers {
         Nil,
         None,
         allowNullsAsPks = false,
-        FieldInserter.embeddedKafkaMetadata(doInsert = true, None))
+        FieldInserter.embeddedKafkaMetadata(doInsert = true, None),
+      )
 
-
-    val record1        = sinkRecord(value1)
+    val record1 = sinkRecord(value1)
     transformer.transform(record1).unsafeRunSync()
-    val record2        = sinkRecord(value2)
+    val record2 = sinkRecord(value2)
 
     val genericRecord = transformer.transform(record2).unsafeRunSync()
 
     genericRecord.get("a_string") shouldEqual "hello again"
     genericRecord.get("an_int") shouldEqual null
     genericRecord.get("a_float") shouldEqual null
-    genericRecord.get("kafkaPartition") shouldEqual record2.kafkaPartition()
-    genericRecord.get("kafkaOffset") shouldEqual record2.kafkaOffset()
-    genericRecord.get("kafkaTimestamp") shouldEqual record2.timestamp()
   }
 
+  test("resets schema when schema evolution fails due to a type error") {
+    val value1 = Map[String, Any](
+      "some_field"       -> "hello",
+      "some_other_field" -> "hello",
+    ).asJava
+
+    val value2 = Map[String, Any](
+      "some_field" -> 22, // field type has changed!
+    ).asJava
+
+    val transformer =
+      RecordTransformer.fromConfig(
+        "mySink",
+        PreConversionConfig(false),
+        Some(FlattenerConfig(discardCollections = true, jsonBlobChunks = None)),
+        Nil,
+        None,
+        allowNullsAsPks = false,
+        FieldInserter.embeddedKafkaMetadata(doInsert = true, None),
+      )
+
+    val record1        = sinkRecord(value1)
+    val genericRecord1 = transformer.transform(record1).unsafeRunSync()
+
+    genericRecord1.hasField("some_field") shouldBe true
+    genericRecord1.hasField("some_other_field") shouldBe true
+
+    val record2        = sinkRecord(value2)
+    val genericRecord2 = transformer.transform(record2).unsafeRunSync()
+
+    genericRecord2.get("some_field") shouldEqual 22
+    genericRecord2.hasField("some_other_field") shouldBe false
+  }
 
   test("With Chunking enabled, heterogeneous arrays are handled properly") {
     val value = Map(


### PR DESCRIPTION
## Highlights

- Port to the connector schema evolution logic implemented elsewhere (hence new sources in Java(. This is aimed at reducing the number of (inefficient) single row parquet files uploaded to EMS when working with schemaless data format (i.e. JSON).
- Gracefully handle the case of a failed evolution due to field type changes. Rather than failing the connector task, in this case we simply log a warning and reset the schema to the newly supplied value.

## Testing

- ported relevant unit tests to Scala
- add coverage for schema evolution in `RecordTransformerTest` suite.