### PR TITLE
DP-2782: Set struct field optionality in schema evolution

### DIFF
--- a/connector/src/main/java/com/celonis/kafka/connect/schema/StructSchemaEvolution.java
+++ b/connector/src/main/java/com/celonis/kafka/connect/schema/StructSchemaEvolution.java
@@ -75,6 +75,8 @@ public class StructSchemaEvolution implements SchemaEvolution {
       throws SchemaEvolutionException {
     SchemaBuilder result = SchemaUtils.withMetadata(SchemaBuilder.struct(), currentSchema);
 
+    if (currentSchema.isOptional() || recordSchema.isOptional()) result.optional();
+
     // First currentSchemaFields
     currentSchema.fields().stream()
         .forEach(

--- a/connector/src/test/scala/com/celonis/kafka/connect/schema/StructSchemaEvolutionTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/schema/StructSchemaEvolutionTest.scala
@@ -183,6 +183,28 @@ class StructSchemaEvolutionTest extends AnyFunSuite with Matchers with Inside {
 
     schemaEv.evolve(currentSchema, recordSchema) shouldEqual expectedResult
   }
+
+  test("testSchemaEvolutionPreservesFieldOptionality") {
+    val currentSchema =
+      SchemaBuilder.struct.field("a_struct",
+                                 SchemaBuilder.struct.field("optional_string", Schema.OPTIONAL_STRING_SCHEMA).build,
+      ).field("an_empty_struct", SchemaBuilder.struct.optional.schema).build
+    val recordSchema = SchemaBuilder.struct.field(
+      "a_struct",
+      SchemaBuilder.struct.optional.field("optional_string", Schema.OPTIONAL_STRING_SCHEMA).field("an_int",
+                                                                                                  Schema.INT64_SCHEMA,
+      ).field("a_string_2", Schema.STRING_SCHEMA).build,
+    ).field("an_empty_struct", SchemaBuilder.struct.schema).build
+    val expectedResult = SchemaBuilder.struct.field(
+      "a_struct",
+      SchemaBuilder.struct.optional.field("optional_string", Schema.OPTIONAL_STRING_SCHEMA).field("an_int",
+                                                                                                  Schema.INT64_SCHEMA,
+      ).field("a_string_2", Schema.STRING_SCHEMA).build,
+    ).field("an_empty_struct", SchemaBuilder.struct.optional.schema).build
+    val result = schemaEv.evolve(currentSchema, recordSchema)
+    result shouldEqual expectedResult
+  }
+
   test("SchemaEvolutionWithAdditionalStructRecordField") {
     val currentSchema =
       SchemaBuilder.struct()


### PR DESCRIPTION
This is a backport of @afiore's DP-2767 from Kafka EMS Connector 2.0

## Background

When running some integration tests using schemaless JSON as input format, we observed a bug where the avro library was complaining due to a nested struct field being set to null (please refer to associated Jira ticket for more details on the failure scenario).

## Root cause analysis and fix

The optional schema attribute was lost during the schema evolution, where we mistakenly forgot to set this field. The fix consists of a conditional statement where we set the schema to optional if either the left or the right term of the merge is optional.

## Testing

- Added a test to the `StructSchemaEvolutionTest` suite where we add coverage for the log detailed above.


