### PR TITLE
DP-2915: transform ENUMs to Strings

### DIFF
--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/flatten/SchemaFlattener.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/flatten/SchemaFlattener.scala
@@ -27,7 +27,6 @@ import scala.jdk.CollectionConverters._
 
 /** Flatten a schema, but also do some normalization:
   *   1. Sanitize non-avro compatible field names 2. Convert Enums to Strings 3. Make everything optional
-  * @param discardCollections
   */
 private final class SchemaFlattener(discardCollections: Boolean) {
   def flatten(schema: Schema): FlatSchema = FlatSchema(flatten(Path.empty, schema))


### PR DESCRIPTION
When reading from AVRO, ENUMs are translated into `ConnectData`strings with some`parameters` created by `AvroData` in order to preserve the information of the original ENUM schema. 

This prevented schema evolution from working when the same field had different enum types, causing very small parquet files to be uploaded in that scenario.

To fix that, this PR introduces a conversion from ENUM into plain Strings. The conversion is implemented in the `SchemaFlattener`.