### PR TITLE
DP-3392: Option to lowercase field names

### DIFF
--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/config/EmsSinkConfigConstants.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/config/EmsSinkConfigConstants.scala
@@ -158,42 +158,47 @@ object EmsSinkConfigConstants {
   val CLOSE_EVERY_CONNECTION_DOC           = "Connection pool - Explicitly close connections"
   val CLOSE_EVERY_CONNECTION_DEFAULT_VALUE = false
 
-  val FLATTENER_ENABLE_KEY = s"${CONNECTOR_PREFIX}.flattener.enable"
+  val FLATTENER_ENABLE_KEY = s"$CONNECTOR_PREFIX.flattener.enable"
   val FLATTENER_ENABLE_DOC =
     s"Enable flattening of nested records. This is likely to be needed if the source data contains nested objects or collections."
   val FLATTENER_ENABLE_DEFAULT = true
 
-  val FLATTENER_DISCARD_COLLECTIONS_KEY = s"${CONNECTOR_PREFIX}.flattener.collections.discard"
+  val FLATTENER_DISCARD_COLLECTIONS_KEY = s"$CONNECTOR_PREFIX.flattener.collections.discard"
   val FLATTENER_DISCARD_COLLECTIONS_DOC =
     "Discard array and map fields at any level of depth. Note that the default handling of collections by the flattener function is to JSON-encode them as nullable STRING fields."
   val FLATTENER_DISCARD_COLLECTIONS_DEFAULT = false
 
-  val FLATTENER_JSONBLOB_CHUNKS_KEY = s"${CONNECTOR_PREFIX}.flattener.jsonblob.chunks"
+  val FLATTENER_JSONBLOB_CHUNKS_KEY = s"$CONNECTOR_PREFIX.flattener.jsonblob.chunks"
   val FLATTENER_JSONBLOB_CHUNKS_DOC =
     "Encodes the record into a JSON blob broken down into N VARCHAR fields (e.g. `payload_chunk1`, `payload_chunk2`, `...`, `payload_chunkN`)."
   val FLATTENER_JSONBLOB_CHUNKS_DEFAULT = null
 
-  val DECIMAL_CONVERSION_KEY = s"${CONNECTOR_PREFIX}.convert.decimals.to.double"
-  val DECIMAL_CONVERSION_KEY_DOC =
+  val DECIMAL_CONVERSION_KEY = s"$CONNECTOR_PREFIX.convert.decimals.to.double"
+  val DECIMAL_CONVERSION_DOC =
     s"Convert decimal values into doubles. Valid only for formats with schema (AVRO, Protobuf, JsonSchema)"
-  val DECIMAL_CONVERSION_KEY_DEFAULT = false
+  val DECIMAL_CONVERSION_DEFAULT = false
 
-  val NULL_PK_KEY = s"${CONNECTOR_PREFIX}.allow.null.pk"
+  val TRANSFORM_FIELDS_LOWERCASE_KEY = s"$CONNECTOR_PREFIX.convert.lowercase.fields"
+  val TRANSFORM_FIELDS_LOWERCASE_DOC =
+    s"Convert all fields to lowercase"
+  val TRANSFORM_FIELDS_LOWERCASE_DEFAULT = false
+
+  val NULL_PK_KEY = s"$CONNECTOR_PREFIX.allow.null.pk"
   val NULL_PK_KEY_DOC =
     s"Allow parsing messages with null values in the columns listed as primary keys. If disabled connector will fail after receiving such a message. NOTE: enabling that will cause data inconsistency issue on the EMS side."
   val NULL_PK_KEY_DEFAULT = false
 
-  val EMBED_KAFKA_EMBEDDED_METADATA_KEY = s"${CONNECTOR_PREFIX}.embed.kafka.metadata"
+  val EMBED_KAFKA_EMBEDDED_METADATA_KEY = s"$CONNECTOR_PREFIX.embed.kafka.metadata"
   val EMBED_KAFKA_EMBEDDED_METADATA_DOC =
     "Embed Kafka metadata such as partition, offset and timestamp as additional record fields."
   val EMBED_KAFKA_EMBEDDED_METADATA_DEFAULT = true
 
-  val USE_IN_MEMORY_FS_KEY = s"${CONNECTOR_PREFIX}.inmemfs.enable"
+  val USE_IN_MEMORY_FS_KEY = s"$CONNECTOR_PREFIX.inmemfs.enable"
   val USE_IN_MEMORY_FS_DOC =
     "Rather than writing to the host file system, buffer parquet data files in memory"
   val USE_IN_MEMORY_FS_DEFAULT = false
 
-  val SINK_PUT_TIMEOUT_KEY = s"${CONNECTOR_PREFIX}.sink.put.timeout.ms"
+  val SINK_PUT_TIMEOUT_KEY = s"$CONNECTOR_PREFIX.sink.put.timeout.ms"
   val SINK_PUT_TIMEOUT_DOC =
     "The maximum time (in milliseconds) for the connector task to complete the upload of a single Parquet file before being flagged as failed. Note: this value should always be lower than max.poll.interval.ms"
   val SINK_PUT_TIMEOUT_DEFAULT = 288000L // 4.8 minutes

--- a/connector/src/main/scala/com/celonis/kafka/connect/ems/config/EmsSinkConfigDef.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/ems/config/EmsSinkConfigDef.scala
@@ -363,9 +363,16 @@ object EmsSinkConfigDef {
     .define(
       DECIMAL_CONVERSION_KEY,
       Type.BOOLEAN,
-      DECIMAL_CONVERSION_KEY_DEFAULT,
+      DECIMAL_CONVERSION_DEFAULT,
       Importance.MEDIUM,
-      DECIMAL_CONVERSION_KEY_DOC,
+      DECIMAL_CONVERSION_DOC,
+    )
+    .define(
+      TRANSFORM_FIELDS_LOWERCASE_KEY,
+      Type.BOOLEAN,
+      TRANSFORM_FIELDS_LOWERCASE_DEFAULT,
+      Importance.MEDIUM,
+      TRANSFORM_FIELDS_LOWERCASE_DOC,
     )
     .define(
       NULL_PK_KEY,

--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/PreConversionConfig.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/PreConversionConfig.scala
@@ -17,14 +17,17 @@
 package com.celonis.kafka.connect.transform
 
 import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants.DECIMAL_CONVERSION_KEY
-import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants.DECIMAL_CONVERSION_KEY_DEFAULT
+import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants.DECIMAL_CONVERSION_DEFAULT
+import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants.TRANSFORM_FIELDS_LOWERCASE_KEY
+import com.celonis.kafka.connect.ems.config.EmsSinkConfigConstants.TRANSFORM_FIELDS_LOWERCASE_DEFAULT
 import com.celonis.kafka.connect.ems.config.PropertiesHelper.getBoolean
 
-final case class PreConversionConfig(convertDecimalsToFloat: Boolean)
+final case class PreConversionConfig(convertDecimalsToFloat: Boolean, convertFieldsToLowercase: Boolean)
 
 object PreConversionConfig {
   def extract(props: Map[String, _]): PreConversionConfig =
     PreConversionConfig(
-      getBoolean(props, DECIMAL_CONVERSION_KEY).getOrElse(DECIMAL_CONVERSION_KEY_DEFAULT),
+      getBoolean(props, DECIMAL_CONVERSION_KEY).getOrElse(DECIMAL_CONVERSION_DEFAULT),
+      getBoolean(props, TRANSFORM_FIELDS_LOWERCASE_KEY).getOrElse(TRANSFORM_FIELDS_LOWERCASE_DEFAULT),
     )
 }

--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/conversion/ConnectConversion.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/conversion/ConnectConversion.scala
@@ -33,8 +33,11 @@ trait ConnectConversion {
 
 object ConnectConversion {
   def fromConfig(config: PreConversionConfig): ConnectConversion =
-    if (config.convertDecimalsToFloat) new RecursiveConversion(DecimalToFloatConversion, identity)
-    else noOpConversion
+    if (config.convertFieldsToLowercase || config.convertDecimalsToFloat) {
+      val inner = if (config.convertDecimalsToFloat) DecimalToFloatConversion else noOpConversion
+      val fieldNameConversion: String => String = if (config.convertFieldsToLowercase) _.toLowerCase else identity
+      new RecursiveConversion(inner, fieldNameConversion)
+    } else noOpConversion
 
   val noOpConversion: ConnectConversion = new ConnectConversion {
     override def convertSchema(originalSchema: Schema): Schema = originalSchema

--- a/connector/src/main/scala/com/celonis/kafka/connect/transform/conversion/ConnectConversion.scala
+++ b/connector/src/main/scala/com/celonis/kafka/connect/transform/conversion/ConnectConversion.scala
@@ -33,7 +33,7 @@ trait ConnectConversion {
 
 object ConnectConversion {
   def fromConfig(config: PreConversionConfig): ConnectConversion =
-    if (config.convertDecimalsToFloat) new RecursiveConversion(DecimalToFloatConversion)
+    if (config.convertDecimalsToFloat) new RecursiveConversion(DecimalToFloatConversion, identity)
     else noOpConversion
 
   val noOpConversion: ConnectConversion = new ConnectConversion {

--- a/connector/src/test/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTaskObfuscationTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/ems/sink/EmsSinkTaskObfuscationTest.scala
@@ -68,7 +68,7 @@ class EmsSinkTaskObfuscationTest extends AnyFunSuite with Matchers with WorkingD
         UnproxiedHttpClientConfig(defaultPoolingConfig),
         ExplodeConfig.None,
         OrderFieldConfig(Some(EmbeddedKafkaMetadataFieldInserter.CelonisOrderFieldName)),
-        PreConversionConfig(convertDecimalsToFloat = false),
+        PreConversionConfig(false, false),
         None,
         embedKafkaMetadata    = false,
         useInMemoryFileSystem = false,

--- a/connector/src/test/scala/com/celonis/kafka/connect/transform/RecordTransformerTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/transform/RecordTransformerTest.scala
@@ -48,7 +48,7 @@ class RecordTransformerTest extends AnyFunSuite with Matchers {
     val transformer =
       RecordTransformer.fromConfig(
         "mySink",
-        PreConversionConfig(false),
+        PreConversionConfig(false, false),
         Some(FlattenerConfig(discardCollections = true, jsonBlobChunks = None)),
         Nil,
         None,
@@ -80,7 +80,7 @@ class RecordTransformerTest extends AnyFunSuite with Matchers {
     val transformer =
       RecordTransformer.fromConfig(
         "mySink",
-        PreConversionConfig(false),
+        PreConversionConfig(false, false),
         Some(FlattenerConfig(discardCollections = true, jsonBlobChunks = None)),
         Nil,
         None,
@@ -184,7 +184,7 @@ class RecordTransformerTest extends AnyFunSuite with Matchers {
     val flattenerConfig = Some(FlattenerConfig(discardCollections = false, Some(JsonBlobChunks(maxChunks, chunkSize))))
     val transformer =
       RecordTransformer.fromConfig("mySink",
-                                   PreConversionConfig(false),
+                                   PreConversionConfig(false, false),
                                    flattenerConfig,
                                    Nil,
                                    None,
@@ -198,7 +198,7 @@ class RecordTransformerTest extends AnyFunSuite with Matchers {
     val flattenerConfig = Some(FlattenerConfig(discardCollections = discardCollections, None))
     val transformer =
       RecordTransformer.fromConfig("mySink",
-                                   PreConversionConfig(false),
+                                   PreConversionConfig(false, false),
                                    flattenerConfig,
                                    Nil,
                                    None,
@@ -210,7 +210,7 @@ class RecordTransformerTest extends AnyFunSuite with Matchers {
 
   private def decimalConversionWithNoFlattening(record: SinkRecord): GenericRecord = {
     val transformer =
-      RecordTransformer.fromConfig("mySink", PreConversionConfig(true), None, Nil, None, false, FieldInserter.noop)
+      RecordTransformer.fromConfig("mySink", PreConversionConfig(true, false), None, Nil, None, false, FieldInserter.noop)
     transformer.transform(record).unsafeRunSync()
   }
 

--- a/connector/src/test/scala/com/celonis/kafka/connect/transform/conversion/ConnectConversionTest.scala
+++ b/connector/src/test/scala/com/celonis/kafka/connect/transform/conversion/ConnectConversionTest.scala
@@ -19,19 +19,47 @@ package com.celonis.kafka.connect.transform.conversion
 import com.celonis.kafka.connect.transform.PreConversionConfig
 import org.apache.kafka.connect.data.Decimal
 import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Timestamp
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 class ConnectConversionTest extends AnyFunSuite with Matchers {
-  test("Build conversion from config") {
-    val conversion = ConnectConversion.fromConfig(PreConversionConfig(convertDecimalsToFloat = true))
+  test("Build conversion for converting decimals") {
+    val conversion =
+      ConnectConversion.fromConfig(PreConversionConfig(convertDecimalsToFloat = true, convertFieldsToLowercase = false))
     conversion shouldBe a[RecursiveConversion]
     conversion.convertSchema(Decimal.schema(5)) shouldBe Schema.FLOAT64_SCHEMA
     conversion.convert(java.math.BigDecimal.ONE, Some(Decimal.schema(5))) shouldBe (1d, Some(Schema.FLOAT64_SCHEMA))
   }
 
-  test("Build noop conversion if convertDecimalsToFloat") {
-    val conversion = ConnectConversion.fromConfig(PreConversionConfig(convertDecimalsToFloat = false))
+  test("Build conversion for converting field names to lowercase") {
+    val conversion =
+      ConnectConversion.fromConfig(PreConversionConfig(convertDecimalsToFloat = false, convertFieldsToLowercase = true))
+    conversion shouldBe a[RecursiveConversion]
+
+    val schema         = SchemaBuilder.struct().field("UPPER", Timestamp.SCHEMA).build()
+    val expectedSchema = SchemaBuilder.struct().field("upper", Timestamp.SCHEMA).build()
+
+    conversion.convertSchema(schema) shouldBe expectedSchema
+  }
+
+  test("Build conversion for converting field names to lowercase and decimals to floats") {
+    val conversion =
+      ConnectConversion.fromConfig(PreConversionConfig(convertDecimalsToFloat = true, convertFieldsToLowercase = true))
+    conversion shouldBe a[RecursiveConversion]
+
+    val schema         = SchemaBuilder.struct().field("DEcimal", Decimal.schema(5)).build()
+    val expectedSchema = SchemaBuilder.struct().field("decimal", Schema.FLOAT64_SCHEMA).build()
+
+    conversion.convertSchema(schema) shouldBe expectedSchema
+  }
+
+  test("Build noop conversion if all conversions are disabled") {
+    val conversion = ConnectConversion.fromConfig(PreConversionConfig(
+      convertDecimalsToFloat   = false,
+      convertFieldsToLowercase = false,
+    ))
     conversion shouldBe ConnectConversion.noOpConversion
     conversion.convertSchema(Decimal.schema(5)) shouldBe Decimal.schema(5)
     conversion.convert(java.math.BigDecimal.ONE, Some(Decimal.schema(5))) shouldBe (java.math.BigDecimal.ONE, Some(


### PR DESCRIPTION
Add a new boolean option `connect.ems.convert.lowercase.fields`, that defaults to `false`.

When set to `true`, all field names in the produced in the parquet will be lowercase. This will be useful in those cases where JSON input data is not clean, and field names are not always given in the same case.

### Details
The conversion has been implemented as a feature of our `RecursiveConverter`, which now accepts an additional functional parameter to transform field names.

`RecursiveConverter`, and therefore the lowercase transformation when set, runs as a `PreConversion`, which means that the conversion will run at the beginning of `RecordTransformer`, before flattening and before schema evolution.